### PR TITLE
Add minimal implementations of indirect and polymorphic with basic allocator support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -61,6 +61,7 @@ cc_test(
     name = "indirect_gtest",
     size = "small",
     srcs = ["indirect_gtest.cc"],
+    defines = ["XYZ_USES_ALLOCATORS=0"],
     deps = [
         "indirect",
         "@com_google_googletest//:gtest_main",
@@ -71,7 +72,7 @@ cc_test(
     name = "indirect_with_allocators_gtest",
     size = "small",
     srcs = ["indirect_gtest.cc"],
-    defines = ["XYZ_INDIRECT_USES_ALLOCATORS"],
+    defines = ["XYZ_USES_ALLOCATORS=1"],
     deps = [
         "indirect_with_allocators",
         "@com_google_googletest//:gtest_main",
@@ -82,6 +83,7 @@ cc_test(
     name = "polymorphic_gtest",
     size = "small",
     srcs = ["polymorphic_gtest.cc"],
+    defines = ["XYZ_USES_ALLOCATORS=0"],
     deps = [
         "polymorphic",
         "@com_google_googletest//:gtest_main",
@@ -92,7 +94,7 @@ cc_test(
     name = "polymorphic_with_allocators_gtest",
     size = "small",
     srcs = ["polymorphic_gtest.cc"],
-    defines = ["XYZ_POLYMORPHIC_USES_ALLOCATORS"],
+    defines = ["XYZ_USES_ALLOCATORS=1"],
     deps = [
         "polymorphic_with_allocators",
         "@com_google_googletest//:gtest_main",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -62,6 +62,17 @@ cc_test(
 )
 
 cc_test(
+    name = "indirect_with_allocators_gtest",
+    size = "small",
+    srcs = ["indirect_gtest.cc"],
+    defines = ["XYZ_INDIRECT_USES_ALLOCATORS"],
+    deps = [
+        "indirect_with_allocators",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "polymorphic_gtest",
     size = "small",
     srcs = ["polymorphic_gtest.cc"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,12 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "polymorphic_with_allocators",
+    hdrs = ["polymorphic_with_allocators.h"],
+    copts = ["-Iexternal/value_types/"],
+)
+
 cc_test(
     name = "polymorphic_test",
     srcs = [
@@ -78,6 +84,17 @@ cc_test(
     srcs = ["polymorphic_gtest.cc"],
     deps = [
         "polymorphic",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "polymorphic_with_allocators_gtest",
+    size = "small",
+    srcs = ["polymorphic_gtest.cc"],
+    defines = ["XYZ_POLYMORPHIC_USES_ALLOCATORS"],
+    deps = [
+        "polymorphic_with_allocators",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,12 @@ cc_library(
     deps = ["copy_and_delete"],
 )
 
+cc_library(
+    name = "indirect_with_allocators",
+    hdrs = ["indirect_with_allocators.h"],
+    copts = ["-Iexternal/value_types/"],
+)
+
 cc_test(
     name = "indirect_test",
     srcs = [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,23 @@ target_compile_features(indirect_with_allocators
         cxx_std_23
 )
 
+add_library(polymorphic_with_allocators INTERFACE)
+target_include_directories(polymorphic_with_allocators
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_sources(polymorphic_with_allocators
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/polymorphic_with_allocators.h>
+)
+
+target_compile_features(polymorphic_with_allocators
+    INTERFACE
+        cxx_std_23
+)
+
 add_library(value_types::value_types ALIAS value_types)
 
 if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
@@ -129,22 +146,23 @@ if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
                 common_compiler_settings
         )
 
-        add_executable(indirect_with_allocators_gtest "")
-        target_sources(indirect_with_allocators_gtest
+        add_executable(value_types_with_allocators_gtest "")
+        target_sources(value_types_with_allocators_gtest
             PRIVATE
                 indirect_gtest.cc
                 polymorphic_gtest.cc
         )
 
-        target_link_libraries(indirect_with_allocators_gtest
+        target_link_libraries(value_types_with_allocators_gtest
             PRIVATE
                 indirect_with_allocators
+                polymorphic_with_allocators
                 GTest::gtest_main
                 common_compiler_settings
         )
-        target_compile_definitions(indirect_with_allocators_gtest 
+        target_compile_definitions(value_types_with_allocators_gtest 
             PRIVATE
-                XYZ_INDIRECT_USES_ALLOCATORS
+                XYZ_USES_ALLOCATORS
         )
 
         if (ENABLE_SANITIZERS)
@@ -203,6 +221,7 @@ if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
         catch_discover_tests(value_types_test)
         include(GoogleTest)
         gtest_discover_tests(value_types_gtest)
+        gtest_discover_tests(value_types_with_allocators_gtest)
 
         if (ENABLE_CODE_COVERAGE)
             FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,10 @@ if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
                 GTest::gtest_main
                 common_compiler_settings
         )
+        target_compile_definitions(indirect_with_allocators_gtest 
+            PRIVATE
+                XYZ_INDIRECT_USES_ALLOCATORS
+        )
 
         if (ENABLE_SANITIZERS)
             set(SANITIZER_FLAGS_ASAN "-fsanitize=address -fno-omit-frame-pointer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,10 @@ if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
                 GTest::gtest_main
                 common_compiler_settings
         )
+        target_compile_definitions(value_types_gtest 
+            PRIVATE
+                XYZ_USES_ALLOCATORS=0
+        )
 
         add_executable(value_types_with_allocators_gtest "")
         target_sources(value_types_with_allocators_gtest
@@ -162,7 +166,7 @@ if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
         )
         target_compile_definitions(value_types_with_allocators_gtest 
             PRIVATE
-                XYZ_USES_ALLOCATORS
+                XYZ_USES_ALLOCATORS=1
         )
 
         if (ENABLE_SANITIZERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,23 @@ target_compile_features(value_types
         cxx_std_23
 )
 
+add_library(indirect_with_allocators INTERFACE)
+target_include_directories(indirect_with_allocators
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_sources(indirect_with_allocators
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/indirect_with_allocators.h>
+)
+
+target_compile_features(indirect_with_allocators
+    INTERFACE
+        cxx_std_23
+)
+
 add_library(value_types::value_types ALIAS value_types)
 
 if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
@@ -68,13 +85,25 @@ if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
             FetchContent_Populate(catch2)
             add_subdirectory(${catch2_SOURCE_DIR} ${catch2_BINARY_DIR})
         endif()
+        add_library(common_compiler_settings INTERFACE)
+
+        target_compile_options(common_compiler_settings
+            INTERFACE
+                $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
+                $<$<CXX_COMPILER_ID:MSVC>:/W4>
+                $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+                $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option>
+        )
+
+        set_target_properties(common_compiler_settings PROPERTIES
+            CXX_STANDARD 23
+            CXX_STANDARD_REQUIRED YES
+            CXX_EXTENSIONS NO
+        )
 
         add_executable(value_types_test "")
         target_sources(value_types_test
             PRIVATE
-                #pimpl.h
-                #pimpl.cpp
-                #pimpl_test.cpp
                 indirect_test.cc
                 polymorphic_test.cc
         )
@@ -83,20 +112,7 @@ if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
             PRIVATE
                 value_types::value_types
                 Catch2::Catch2WithMain
-        )
-
-        target_compile_options(value_types_test
-            PRIVATE
-                $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
-                $<$<CXX_COMPILER_ID:MSVC>:/W4>
-                $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
-                $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option>
-        )
-
-        set_target_properties(value_types_test PROPERTIES
-            CXX_STANDARD 23
-            CXX_STANDARD_REQUIRED YES
-            CXX_EXTENSIONS NO
+                common_compiler_settings
         )
 
         add_executable(value_types_gtest "")
@@ -110,20 +126,21 @@ if (${CPP_VALUE_TYPES_IS_NOT_SUBPROJECT})
             PRIVATE
                 value_types::value_types
                 GTest::gtest_main
+                common_compiler_settings
         )
 
-        target_compile_options(value_types_gtest
+        add_executable(indirect_with_allocators_gtest "")
+        target_sources(indirect_with_allocators_gtest
             PRIVATE
-                $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
-                $<$<CXX_COMPILER_ID:MSVC>:/W4>
-                $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
-                $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option>
+                indirect_gtest.cc
+                polymorphic_gtest.cc
         )
 
-        set_target_properties(value_types_gtest PROPERTIES
-            CXX_STANDARD 23
-            CXX_STANDARD_REQUIRED YES
-            CXX_EXTENSIONS NO
+        target_link_libraries(indirect_with_allocators_gtest
+            PRIVATE
+                indirect_with_allocators
+                GTest::gtest_main
+                common_compiler_settings
         )
 
         if (ENABLE_SANITIZERS)

--- a/indirect_gtest.cc
+++ b/indirect_gtest.cc
@@ -22,11 +22,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <utility>
 
-#ifdef XYZ_INDIRECT_USES_ALLOCATORS
+#ifndef XYZ_USES_ALLOCATORS
+#error "XYZ_USES_ALLOCATORS must be defined"
+#endif // XYZ_USES_ALLOCATORS
+#if XYZ_USES_ALLOCATORS == 1
 #include "indirect_with_allocators.h"
-#else
+#elif XYZ_USES_ALLOCATORS == 0
 #include "indirect.h"
-#endif
+#else
+#error "XYZ_USES_ALLOCATORS must be 0 or 1"
+#endif  // XYZ_USES_ALLOCATORS == 0 or 1
 
 TEST(IndirectTest, ValueAccess) {
   xyz::indirect<int> a(std::in_place, 42);

--- a/indirect_gtest.cc
+++ b/indirect_gtest.cc
@@ -22,7 +22,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <utility>
 
+#ifdef XYZ_INDIRECT_USES_ALLOCATORS
+#include "indirect_with_allocators.h"
+#else
 #include "indirect.h"
+#endif
+
+TEST(IndirectTest, ValueAccess) {
+  xyz::indirect<int> a(std::in_place, 42);
+  EXPECT_EQ(*a, 42);
+}
 
 TEST(IndirectTest, CopiesAreDistinct) {
   xyz::indirect<int> a(std::in_place, 42);

--- a/indirect_gtest.cc
+++ b/indirect_gtest.cc
@@ -20,11 +20,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <utility>
 
 #ifndef XYZ_USES_ALLOCATORS
 #error "XYZ_USES_ALLOCATORS must be defined"
-#endif // XYZ_USES_ALLOCATORS
+#endif  // XYZ_USES_ALLOCATORS
 #if XYZ_USES_ALLOCATORS == 1
 #include "indirect_with_allocators.h"
 #elif XYZ_USES_ALLOCATORS == 0
@@ -57,7 +58,7 @@ TEST(IndirectTest, CopyAssignment) {
   xyz::indirect<int> b(std::in_place, 101);
   EXPECT_EQ(*a, 42);
   a = b;
-  
+
   EXPECT_EQ(*a, 101);
   EXPECT_NE(&*a, &*b);
 }
@@ -67,7 +68,7 @@ TEST(IndirectTest, MoveAssignment) {
   xyz::indirect<int> b(std::in_place, 101);
   EXPECT_EQ(*a, 42);
   a = std::move(b);
-  
+
   EXPECT_EQ(*a, 101);
 }
 
@@ -75,7 +76,7 @@ TEST(IndirectTest, NonMemberSwap) {
   xyz::indirect<int> a(std::in_place, 42);
   xyz::indirect<int> b(std::in_place, 101);
   using std::swap;
-  swap(a,b);
+  swap(a, b);
   EXPECT_EQ(*a, 101);
   EXPECT_EQ(*b, 42);
 }
@@ -107,6 +108,14 @@ TEST(IndirectTest, ConstPropagation) {
 TEST(IndirectTest, Hash) {
   xyz::indirect<int> a(std::in_place, 42);
   EXPECT_EQ(std::hash<xyz::indirect<int>>()(a), std::hash<int>()(*a));
+}
+
+TEST(IndirectTest, Optional) {
+  std::optional<xyz::indirect<int>> a;
+  EXPECT_FALSE(a.has_value());
+  a.emplace(std::in_place, 42);
+  EXPECT_TRUE(a.has_value());
+  EXPECT_EQ(**a, 42);
 }
 
 #if false  // Indirect does not support == and != yet.

--- a/indirect_gtest.cc
+++ b/indirect_gtest.cc
@@ -52,6 +52,43 @@ TEST(IndirectTest, MovePreservesIndirectObjectAddress) {
   EXPECT_EQ(address, &*aa);
 }
 
+TEST(IndirectTest, CopyAssignment) {
+  xyz::indirect<int> a(std::in_place, 42);
+  xyz::indirect<int> b(std::in_place, 101);
+  EXPECT_EQ(*a, 42);
+  a = b;
+  
+  EXPECT_EQ(*a, 101);
+  EXPECT_NE(&*a, &*b);
+}
+
+TEST(IndirectTest, MoveAssignment) {
+  xyz::indirect<int> a(std::in_place, 42);
+  xyz::indirect<int> b(std::in_place, 101);
+  EXPECT_EQ(*a, 42);
+  a = std::move(b);
+  
+  EXPECT_EQ(*a, 101);
+}
+
+TEST(IndirectTest, NonMemberSwap) {
+  xyz::indirect<int> a(std::in_place, 42);
+  xyz::indirect<int> b(std::in_place, 101);
+  using std::swap;
+  swap(a,b);
+  EXPECT_EQ(*a, 101);
+  EXPECT_EQ(*b, 42);
+}
+
+TEST(IndirectTest, MemberSwap) {
+  xyz::indirect<int> a(std::in_place, 42);
+  xyz::indirect<int> b(std::in_place, 101);
+
+  a.swap(b);
+  EXPECT_EQ(*a, 101);
+  EXPECT_EQ(*b, 42);
+}
+
 TEST(IndirectTest, ConstPropagation) {
   struct SomeType {
     enum class Constness { CONST, NON_CONST };
@@ -65,18 +102,6 @@ TEST(IndirectTest, ConstPropagation) {
   const auto& ca = a;
   EXPECT_EQ(ca->member(), SomeType::Constness::CONST);
   EXPECT_EQ((*ca).member(), SomeType::Constness::CONST);
-}
-
-TEST(IndirectTest, Swap) {
-  xyz::indirect<int> a(std::in_place, 42);
-  xyz::indirect<int> b(std::in_place, 43);
-  auto address_a = &*a;
-  auto address_b = &*b;
-  swap(a, b);
-  EXPECT_EQ(*a, 43);
-  EXPECT_EQ(*b, 42);
-  EXPECT_EQ(address_a, &*b);
-  EXPECT_EQ(address_b, &*a);
 }
 
 TEST(IndirectTest, Hash) {

--- a/indirect_with_allocators.h
+++ b/indirect_with_allocators.h
@@ -1,3 +1,5 @@
+#ifndef INDIRECT_WITH_ALLOCATORS_H
+#define INDIRECT_WITH_ALLOCATORS_H
 #include <memory>
 #include <utility>
 
@@ -98,3 +100,5 @@ struct std::hash<xyz::indirect<T>> {
     return std::hash<typename xyz::indirect<T>::value_type>{}(*key);
   }
 };
+
+#endif  // INDIRECT_WITH_ALLOCATORS_H

--- a/indirect_with_allocators.h
+++ b/indirect_with_allocators.h
@@ -1,0 +1,82 @@
+#include <memory>
+#include <utility>
+
+namespace xyz {
+template <class T, class A = std::allocator<T>>
+class indirect {
+  T* p_;
+  [[no_unique_address]] A alloc_;
+
+  using t_traits = std::allocator_traits<A>;
+
+ public:
+  indirect() {
+    T* mem = t_traits::allocate(alloc_, 1);
+    t_traits::construct(alloc_, mem);
+  }
+
+  template <class... Ts>
+  indirect(std::in_place_t, Ts&&... ts) {
+    T* mem = t_traits::allocate(alloc_, 1);
+    t_traits::construct(alloc_, mem, std::forward<Ts>(ts)...);
+  }
+
+  indirect(const indirect& other) {
+    T* mem = t_traits::allocate(alloc_, 1);
+    t_traits::construct(alloc_, mem, *other);
+  }
+
+  indirect(indirect&& other) noexcept : p_(nullptr) { swap(p_, other.p_); }
+
+  ~indirect() { reset(); }
+
+  operator=(const indirect& other) {
+    assert(other.p_ != nullptr);
+    indirect tmp(std::in_place, *other.p_);
+    return *this;
+  }
+
+  operator=(indirect&& other) noexcept {
+    assert(other.p_ != nullptr);
+    p_ = std::exchange(other.p_, nullptr);
+    return *this;
+  }
+
+  void swap(indirect& other) noexcept {
+    assert(p_ != nullptr);
+    return p_;
+  }
+
+  const T& operator*() const noexcept {
+    assert(p_ != nullptr);
+    return *p_;
+  }
+
+  T& operator*() noexcept {
+    assert(p_ != nullptr);
+    return *p_;
+  }
+
+  const T* operator->() const noexcept {
+    assert(p_ != nullptr);
+    return p_;
+  }
+
+  T* operator->() noexcept {
+    assert(p_ != nullptr);
+    return p_;
+  }
+
+  friend void swap(indirect& lhs, indirect& rhs) noexcept {
+    swap(lhs.p_, rhs.p_);
+  }
+
+ private:
+  void reset() {
+    if (p_ == nullptr) return;
+    t_traits::destroy(alloc, p_);
+    t_traits::deallocate(alloc, p_, 1);
+    p_ = nullptr;
+  }
+};
+}  // namespace xyz

--- a/indirect_with_allocators.h
+++ b/indirect_with_allocators.h
@@ -1,5 +1,5 @@
-#ifndef INDIRECT_WITH_ALLOCATORS_H
-#define INDIRECT_WITH_ALLOCATORS_H
+#ifndef XYZ_INDIRECT_WITH_ALLOCATORS_H
+#define XYZ_INDIRECT_WITH_ALLOCATORS_H
 #include <memory>
 #include <utility>
 
@@ -9,28 +9,28 @@ class indirect {
   T* p_;
   [[no_unique_address]] A alloc_;
 
-  using t_traits = std::allocator_traits<A>;
+  using allocator_traits = std::allocator_traits<A>;
 
  public:
   using value_type = T;
 
   indirect() {
-    T* mem = t_traits::allocate(alloc_, 1);
-    t_traits::construct(alloc_, mem);
+    T* mem = allocator_traits::allocate(alloc_, 1);
+    allocator_traits::construct(alloc_, mem);
     p_ = mem;
   }
 
   template <class... Ts>
   indirect(std::in_place_t, Ts&&... ts) {
-    T* mem = t_traits::allocate(alloc_, 1);
-    t_traits::construct(alloc_, mem, std::forward<Ts>(ts)...);
+    T* mem = allocator_traits::allocate(alloc_, 1);
+    allocator_traits::construct(alloc_, mem, std::forward<Ts>(ts)...);
     p_ = mem;
   }
 
   indirect(const indirect& other) {
     assert(other.p_ != nullptr);
-    T* mem = t_traits::allocate(alloc_, 1);
-    t_traits::construct(alloc_, mem, *other);
+    T* mem = allocator_traits::allocate(alloc_, 1);
+    allocator_traits::construct(alloc_, mem, *other);
     p_ = mem;
   }
 
@@ -87,8 +87,8 @@ class indirect {
  private:
   void reset() {
     if (p_ == nullptr) return;
-    t_traits::destroy(alloc_, p_);
-    t_traits::deallocate(alloc_, p_, 1);
+    allocator_traits::destroy(alloc_, p_);
+    allocator_traits::deallocate(alloc_, p_, 1);
     p_ = nullptr;
   }
 };
@@ -101,4 +101,4 @@ struct std::hash<xyz::indirect<T>> {
   }
 };
 
-#endif  // INDIRECT_WITH_ALLOCATORS_H
+#endif  // XYZ_INDIRECT_WITH_ALLOCATORS_H

--- a/indirect_with_allocators.h
+++ b/indirect_with_allocators.h
@@ -10,33 +10,41 @@ class indirect {
   using t_traits = std::allocator_traits<A>;
 
  public:
+  using value_type = T;
+
   indirect() {
     T* mem = t_traits::allocate(alloc_, 1);
     t_traits::construct(alloc_, mem);
+    p_ = mem;
   }
 
   template <class... Ts>
   indirect(std::in_place_t, Ts&&... ts) {
     T* mem = t_traits::allocate(alloc_, 1);
     t_traits::construct(alloc_, mem, std::forward<Ts>(ts)...);
+    p_ = mem;
   }
 
   indirect(const indirect& other) {
     T* mem = t_traits::allocate(alloc_, 1);
     t_traits::construct(alloc_, mem, *other);
+    p_ = mem;
   }
 
-  indirect(indirect&& other) noexcept : p_(nullptr) { swap(p_, other.p_); }
+  indirect(indirect&& other) noexcept : p_(nullptr) {
+    using std::swap;
+    swap(p_, other.p_);
+  }
 
   ~indirect() { reset(); }
 
-  operator=(const indirect& other) {
+  indirect& operator=(const indirect& other) {
     assert(other.p_ != nullptr);
     indirect tmp(std::in_place, *other.p_);
     return *this;
   }
 
-  operator=(indirect&& other) noexcept {
+  indirect& operator=(indirect&& other) noexcept {
     assert(other.p_ != nullptr);
     p_ = std::exchange(other.p_, nullptr);
     return *this;
@@ -64,19 +72,28 @@ class indirect {
 
   void swap(indirect& other) noexcept {
     assert(p_ != nullptr);
-    return p_;
+    using std::swap;
+    swap(p_, other.p_);
   }
-  
+
   friend void swap(indirect& lhs, indirect& rhs) noexcept {
+    using std::swap;
     swap(lhs.p_, rhs.p_);
   }
 
  private:
   void reset() {
     if (p_ == nullptr) return;
-    t_traits::destroy(alloc, p_);
-    t_traits::deallocate(alloc, p_, 1);
+    t_traits::destroy(alloc_, p_);
+    t_traits::deallocate(alloc_, p_, 1);
     p_ = nullptr;
   }
 };
 }  // namespace xyz
+
+template <class T>
+struct std::hash<xyz::indirect<T>> {
+  constexpr std::size_t operator()(const xyz::indirect<T>& key) const {
+    return std::hash<typename xyz::indirect<T>::value_type>{}(*key);
+  }
+};

--- a/indirect_with_allocators.h
+++ b/indirect_with_allocators.h
@@ -42,11 +42,6 @@ class indirect {
     return *this;
   }
 
-  void swap(indirect& other) noexcept {
-    assert(p_ != nullptr);
-    return p_;
-  }
-
   const T& operator*() const noexcept {
     assert(p_ != nullptr);
     return *p_;
@@ -67,6 +62,11 @@ class indirect {
     return p_;
   }
 
+  void swap(indirect& other) noexcept {
+    assert(p_ != nullptr);
+    return p_;
+  }
+  
   friend void swap(indirect& lhs, indirect& rhs) noexcept {
     swap(lhs.p_, rhs.p_);
   }

--- a/indirect_with_allocators.h
+++ b/indirect_with_allocators.h
@@ -13,6 +13,7 @@ class indirect {
 
  public:
   using value_type = T;
+  using allocator_type = A;
 
   indirect() {
     T* mem = allocator_traits::allocate(alloc_, 1);
@@ -45,6 +46,7 @@ class indirect {
   indirect& operator=(const indirect& other) {
     assert(other.p_ != nullptr);
     indirect tmp(std::in_place, *other.p_);
+    swap(tmp);
     return *this;
   }
 

--- a/indirect_with_allocators.h
+++ b/indirect_with_allocators.h
@@ -26,12 +26,14 @@ class indirect {
   }
 
   indirect(const indirect& other) {
+    assert(other.p_ != nullptr);
     T* mem = t_traits::allocate(alloc_, 1);
     t_traits::construct(alloc_, mem, *other);
     p_ = mem;
   }
 
   indirect(indirect&& other) noexcept : p_(nullptr) {
+    assert(other.p_ != nullptr);
     using std::swap;
     swap(p_, other.p_);
   }
@@ -71,7 +73,6 @@ class indirect {
   }
 
   void swap(indirect& other) noexcept {
-    assert(p_ != nullptr);
     using std::swap;
     swap(p_, other.p_);
   }

--- a/polymorphic_gtest.cc
+++ b/polymorphic_gtest.cc
@@ -33,6 +33,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #error "XYZ_USES_ALLOCATORS must be 0 or 1"
 #endif  // XYZ_USES_ALLOCATORS == 0 or 1
 
+#if XYZ_USES_ALLOCATORS == 1
+#define XYZ_ALLOC_TEST(S, N) \
+  TEST(S, N)
+#else
+#define XYZ_ALLOC_TEST(S, N) \
+  TEST(S, DISABLED_##N)
+#endif  // XYZ_USES_ALLOCATORS == 1
+
 class A {
   int value_ = 0;
 
@@ -57,16 +65,12 @@ TEST(PolymorphicTest, CopiesAreDistinct) {
   EXPECT_NE(&*a, &*aa);
 }
 
-#if XYZ_USES_ALLOCATORS == 1
-TEST(PolymorphicTest, MovePreservesOwnedObjectAddress) {
+XYZ_ALLOC_TEST(PolymorphicTest, MovePreservesOwnedObjectAddress) {
   xyz::polymorphic<A> a(std::in_place_type<A>, 42);
   auto address = &*a;
   auto aa = std::move(a);
   EXPECT_EQ(address, &*aa);
 }
-#else
-TEST(PolymorphicTest, DISABLED_MovePreservesOwnedObjectAddress) {}
-#endif  // XYZ_USES_ALLOCATORS == 1
 
 TEST(PolymorphicTest, ConstPropagation) {
   struct SomeType {
@@ -119,13 +123,9 @@ TEST(PolymorphicTest, CopiesOfDerivedObjectsAreDistinct) {
   EXPECT_NE(&*a, &*aa);
 }
 
-#if XYZ_USES_ALLOCATORS == 1
-TEST(PolymorphicTest, MovePreservesOwnedDerivedObjectAddress) {
+XYZ_ALLOC_TEST(PolymorphicTest, MovePreservesOwnedDerivedObjectAddress) {
   xyz::polymorphic<Base> a(std::in_place_type<Derived>, 42);
   auto address = &*a;
   auto aa = std::move(a);
   EXPECT_EQ(address, &*aa);
 }
-#else
-TEST(PolymorphicTest, DISABLED_MovePreservesOwnedDerivedObjectAddress) {}
-#endif  // XYZ_USES_ALLOCATORS == 1

--- a/polymorphic_gtest.cc
+++ b/polymorphic_gtest.cc
@@ -26,15 +26,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef XYZ_USES_ALLOCATORS
 #error "XYZ_USES_ALLOCATORS must be defined"
 #endif  // XYZ_USES_ALLOCATORS
-#if XYZ_USES_ALLOCATORS == 1
+#if (XYZ_USES_ALLOCATORS == 1)
 #include "polymorphic_with_allocators.h"
-#elif XYZ_USES_ALLOCATORS == 0
+#elif (XYZ_USES_ALLOCATORS == 0)
 #include "polymorphic.h"
 #else
 #error "XYZ_USES_ALLOCATORS must be 0 or 1"
 #endif  // XYZ_USES_ALLOCATORS == 0 or 1
 
-#if XYZ_USES_ALLOCATORS == 1
+#if (XYZ_USES_ALLOCATORS == 1)
 #define XYZ_ALLOC_TEST(S, N) TEST(S, N)
 #else
 #define XYZ_ALLOC_TEST(S, N) TEST(S, DISABLED_##N)
@@ -131,6 +131,8 @@ XYZ_ALLOC_TEST(PolymorphicTest, MovePreservesOwnedDerivedObjectAddress) {
   EXPECT_EQ(address, &*aa);
 }
 
+#if (XYZ_USES_ALLOCATORS == 1)
+
 // TODO: Use the allocator to count allocations.
 std::mutex alloc_counter_mutex;
 static unsigned alloc_counter = 0;
@@ -162,14 +164,13 @@ struct TrackingAllocator {
   }
 };
 
-XYZ_ALLOC_TEST(PolymorphicTest, CountAllocationsForInPlaceConstruction) {
+TEST(PolymorphicTest, CountAllocationsForInPlaceConstruction) {
   // TODO: Use the allocator to count allocations.
   std::lock_guard<std::mutex> lock(alloc_counter_mutex);
   alloc_counter = 0;
   dealloc_counter = 0;
   {
-    xyz::polymorphic<A, TrackingAllocator<A>> a(
-        std::in_place_type<A>, 42);
+    xyz::polymorphic<A, TrackingAllocator<A>> a(std::in_place_type<A>, 42);
     EXPECT_EQ(alloc_counter, 1);
     EXPECT_EQ(dealloc_counter, 0);
   }
@@ -177,7 +178,7 @@ XYZ_ALLOC_TEST(PolymorphicTest, CountAllocationsForInPlaceConstruction) {
   EXPECT_EQ(dealloc_counter, 1);
 }
 
-XYZ_ALLOC_TEST(PolymorphicTest, CountAllocationsForDerivedTypeConstruction) {
+TEST(PolymorphicTest, CountAllocationsForDerivedTypeConstruction) {
   // TODO: Use the allocator to count allocations.
   std::lock_guard<std::mutex> lock(alloc_counter_mutex);
   alloc_counter = 0;
@@ -191,5 +192,5 @@ XYZ_ALLOC_TEST(PolymorphicTest, CountAllocationsForDerivedTypeConstruction) {
   EXPECT_EQ(alloc_counter, 1);
   EXPECT_EQ(dealloc_counter, 1);
 }
-
+#endif  // (XYZ_USES_ALLOCATORS == 1)
 }  // namespace

--- a/polymorphic_gtest.cc
+++ b/polymorphic_gtest.cc
@@ -22,7 +22,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <utility>
 
+#ifdef XYZ_POLYMORPHIC_USES_ALLOCATORS
+#include "polymorphic_with_allocators.h"
+#else
 #include "polymorphic.h"
+#endif
 
 class A {
   int value_ = 0;

--- a/polymorphic_gtest.cc
+++ b/polymorphic_gtest.cc
@@ -21,6 +21,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <gtest/gtest.h>
 
 #include <mutex>
+#include <optional>
 #include <utility>
 
 #ifndef XYZ_USES_ALLOCATORS
@@ -136,7 +137,7 @@ TEST(PolymorphicTest, CopyAssignment) {
   xyz::polymorphic<Base> b(std::in_place_type<Derived>, 101);
   EXPECT_EQ(a->value(), 42);
   a = b;
-  
+
   EXPECT_EQ(a->value(), 101);
   EXPECT_NE(&*a, &*b);
 }
@@ -146,7 +147,7 @@ TEST(PolymorphicTest, MoveAssignment) {
   xyz::polymorphic<Base> b(std::in_place_type<Derived>, 101);
   EXPECT_EQ(a->value(), 42);
   a = std::move(b);
-  
+
   EXPECT_EQ(a->value(), 101);
 }
 
@@ -154,7 +155,7 @@ TEST(PolymorphicTest, NonMemberSwap) {
   xyz::polymorphic<Base> a(std::in_place_type<Derived>, 42);
   xyz::polymorphic<Base> b(std::in_place_type<Derived>, 101);
   using std::swap;
-  swap(a,b);
+  swap(a, b);
   EXPECT_EQ(a->value(), 101);
   EXPECT_EQ(b->value(), 42);
 }
@@ -181,6 +182,14 @@ TEST(IndirectTest, ConstPropagation) {
   const auto& ca = a;
   EXPECT_EQ(ca->member(), SomeType::Constness::CONST);
   EXPECT_EQ((*ca).member(), SomeType::Constness::CONST);
+}
+
+TEST(PolymorphicTest, Optional) {
+  std::optional<xyz::polymorphic<Base>> a;
+  EXPECT_FALSE(a.has_value());
+  a.emplace(std::in_place_type<Derived>, 42);
+  EXPECT_TRUE(a.has_value());
+  EXPECT_EQ((*a)->value(), 42);
 }
 
 #if (XYZ_USES_ALLOCATORS == 1)

--- a/polymorphic_with_allocators.h
+++ b/polymorphic_with_allocators.h
@@ -90,10 +90,7 @@ class polymorphic {
 
   polymorphic(polymorphic&& other) noexcept {
     assert(other.cb_ != nullptr);
-
-    using std::swap;
-    swap(cb_, other.cb_);
-    cb_ = nullptr;
+    cb_ = std::exchange(other.cb_, nullptr);
   }
 
   ~polymorphic() { reset(); }

--- a/polymorphic_with_allocators.h
+++ b/polymorphic_with_allocators.h
@@ -1,0 +1,157 @@
+#ifndef XYZ_POLYMORPHIC_WITH_ALLOCATORS_H
+#define XYZ_POLYMORPHIC_WITH_ALLOCATORS_H
+
+#include <memory>
+#include <utility>
+
+namespace xyz {
+
+namespace detail {
+template <class T, class A>
+struct control_block {
+  virtual ~control_block() = default;
+  virtual void destroy() = 0;
+  virtual T* get() noexcept = 0;
+  virtual const T* get() const noexcept = 0;
+  virtual control_block<T, A>* clone() = 0;
+};
+
+template <class T, class U, class A>
+class direct_control_block : public control_block<T, A> {
+  U u_;
+  [[no_unique_address]] A alloc_;
+
+ public:
+  template <class... Ts>
+  direct_control_block(A alloc, Ts&&... ts)
+      : u_(std::forward<Ts>(ts)...), alloc_(alloc) {}
+
+  T* get() noexcept override { return &u_; }
+
+  const T* get() const noexcept override { return &u_; }
+
+  control_block<T, A>* clone() override {
+    using cb_allocator = typename std::allocator_traits<
+        A>::template rebind_alloc<direct_control_block<T, U, A>>;
+    cb_allocator cb_alloc(alloc_);
+    using cb_alloc_traits = std::allocator_traits<cb_allocator>;
+    direct_control_block<T, U, A>* mem = cb_alloc_traits::allocate(cb_alloc, 1);
+    cb_alloc_traits::construct(cb_alloc, mem, alloc_, u_);
+    return mem;
+  }
+
+  void destroy() override {
+    using cb_allocator = typename std::allocator_traits<
+        A>::template rebind_alloc<direct_control_block<T, U, A>>;
+    cb_allocator cb_alloc(alloc_);
+    using cb_alloc_traits = std::allocator_traits<cb_allocator>;
+    cb_alloc_traits::destroy(cb_alloc, this);
+    cb_alloc_traits::deallocate(cb_alloc, this, 1);
+  }
+};
+
+}  // namespace detail
+
+template <class T, class A = std::allocator<T>>
+class polymorphic {
+  detail::control_block<T, A>* cb_;
+  [[no_unique_address]] A alloc_;
+
+ public:
+  using value_type = T;
+  using allocator_type = A;
+
+  polymorphic() {
+    using cb_allocator = typename std::allocator_traits<
+        A>::template rebind_alloc<detail::direct_control_block<T, T, A>>;
+    using cb_traits = std::allocator_traits<cb_allocator>;
+    cb_allocator cb_alloc(alloc_);
+    auto* mem = cb_traits::allocate(cb_alloc, 1);
+    cb_traits::construct(cb_alloc, mem, A{});
+    cb_ = mem;
+  }
+
+  template <class U, class... Ts>
+  polymorphic(std::in_place_type_t<U>, Ts&&... ts) {
+    using cb_allocator = typename std::allocator_traits<
+        A>::template rebind_alloc<detail::direct_control_block<T, U, A>>;
+    using cb_traits = std::allocator_traits<cb_allocator>;
+    cb_allocator cb_alloc(alloc_);
+    auto* mem = cb_traits::allocate(cb_alloc, 1);
+    cb_traits::construct(cb_alloc, mem, A{}, std::forward<Ts>(ts)...);
+    cb_ = mem;
+  }
+
+  polymorphic(const polymorphic& other) {
+    assert(other.cb_ != nullptr);
+
+    cb_ = other.cb_->clone();
+  }
+
+  polymorphic(polymorphic&& other) noexcept {
+    assert(other.cb_ != nullptr);
+
+    using std::swap;
+    swap(cb_, other.cb_);
+    cb_ = nullptr;
+  }
+
+  ~polymorphic() { reset(); }
+
+  polymorphic& operator=(const polymorphic& other) {
+    assert(other.cb_ != nullptr);
+
+    polymorphic tmp(other);
+    swap(tmp);
+    return *this;
+  }
+
+  polymorphic& operator=(polymorphic&& other) noexcept {
+    assert(other.cb_ != nullptr);
+
+    using std::swap;
+    swap(cb_, other.cb_);
+    return *this;
+  }
+
+  T* operator->() noexcept {
+    assert(cb_ != nullptr);
+    return cb_->get();
+  }
+
+  const T* operator->() const noexcept {
+    assert(cb_ != nullptr);
+    return cb_->get();
+  }
+
+  T& operator*() noexcept {
+    assert(cb_ != nullptr);
+    return *cb_->get();
+  }
+
+  const T& operator*() const noexcept {
+    assert(cb_ != nullptr);
+    return *cb_->get();
+  }
+
+  void swap(polymorphic& other) noexcept {
+    using std::swap;
+    swap(cb_, other.cb_);
+  }
+
+  friend void swap(polymorphic& lhs, polymorphic& rhs) noexcept {
+    using std::swap;
+    swap(lhs.cb_, rhs.cb_);
+  }
+
+ private:
+  void reset() {
+    if (cb_ != nullptr) {
+      cb_->destroy();
+    }
+    cb_ = nullptr;
+  }
+};
+
+}  // namespace xyz
+#endif  // XYZ_POLYMORPHIC_WITH_ALLOCATORS_H

--- a/polymorphic_with_allocators.h
+++ b/polymorphic_with_allocators.h
@@ -84,7 +84,6 @@ class polymorphic {
 
   polymorphic(const polymorphic& other) {
     assert(other.cb_ != nullptr);
-
     cb_ = other.cb_->clone();
   }
 
@@ -97,7 +96,6 @@ class polymorphic {
 
   polymorphic& operator=(const polymorphic& other) {
     assert(other.cb_ != nullptr);
-
     polymorphic tmp(other);
     swap(tmp);
     return *this;
@@ -105,7 +103,6 @@ class polymorphic {
 
   polymorphic& operator=(polymorphic&& other) noexcept {
     assert(other.cb_ != nullptr);
-
     using std::swap;
     swap(cb_, other.cb_);
     return *this;
@@ -145,8 +142,8 @@ class polymorphic {
   void reset() {
     if (cb_ != nullptr) {
       cb_->destroy();
+      cb_ = nullptr;
     }
-    cb_ = nullptr;
   }
 };
 


### PR DESCRIPTION
Constructors taking an allocator should be added in a later PR.

More allocator-focussed tests should be added to ensure that we're cleaning things up correctly (again a later PR).