### PR TITLE
Make indirect-assign conditionally not allocate

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -445,9 +445,13 @@ indirect& operator=(const indirect& other);
 
 * _Preconditions_: `other` is not valueless.
 
-* _Effects_: If `*this` is not valueless, destroys the owned object. Then,
-  constructs an owned object using the copy constructor of the object owned by
-  `other`.
+* _Effects_: If `*this` is not valueless and `std::is_copy_assignable_v<T>` is
+  true, then the owned object in `*this` is copy assigned from the owned object
+  in `other`. Otherwise if `*this` is not valueless and
+  `std::is_copy_assignable_v<T>` is false, destroys the owned object and then,
+  constructs a new owned object using the copy constructor of the object owned
+  by `other`. Otherwise if `*this` is valueless, constructs an owned object
+  using the copy constructor of the object owned by `other`.
 
 * _Postconditions_: `*this` is not valueless.
 

--- a/indirect.h
+++ b/indirect.h
@@ -140,8 +140,23 @@ class indirect {
     requires std::copy_constructible<T>
   {
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
-    indirect tmp(other);
-    this->swap(tmp);
+    if constexpr (std::is_copy_assignable_v<T>) {
+      if (p_ == nullptr) {
+        T* mem = allocator_traits::allocate(alloc_, 1);
+        try {
+          allocator_traits::construct(alloc_, mem, *other);
+          p_ = mem;
+        } catch (...) {
+          allocator_traits::deallocate(alloc_, mem, 1);
+          throw;
+        }
+      } else {
+        *p_ = *other.p_;
+      }
+    } else {
+      indirect tmp(other);
+      this->swap(tmp);
+    }
     return *this;
   }
 

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -378,6 +378,33 @@ TEST(IndirectTest, CountAllocationsForMoveAssignment) {
   EXPECT_EQ(dealloc_counter, 2);
 }
 
+TEST(IndirectTest, CountAllocationsForAssignmentToMovedFromObject) {
+  unsigned alloc_counter = 0;
+  unsigned dealloc_counter = 0;
+  {
+    xyz::indirect<int, TrackingAllocator<int>> a(
+        std::allocator_arg,
+        TrackingAllocator<int>(&alloc_counter, &dealloc_counter), std::in_place,
+        42);
+    xyz::indirect<int, TrackingAllocator<int>> b(
+        std::allocator_arg,
+        TrackingAllocator<int>(&alloc_counter, &dealloc_counter), std::in_place,
+        101);
+    EXPECT_EQ(alloc_counter, 2);
+    EXPECT_EQ(dealloc_counter, 0);
+    b = std::move(a);
+    EXPECT_EQ(dealloc_counter, 1);
+    a = xyz::indirect<int, TrackingAllocator<int>>(
+        std::allocator_arg,
+        TrackingAllocator<int>(&alloc_counter, &dealloc_counter), std::in_place,
+        404);
+    EXPECT_EQ(alloc_counter, 3);
+    EXPECT_EQ(dealloc_counter, 1);
+  }
+  EXPECT_EQ(alloc_counter, 3);
+  EXPECT_EQ(dealloc_counter, 3);
+}
+
 TEST(IndirectTest, CountAllocationsForMoveConstruction) {
   unsigned alloc_counter = 0;
   unsigned dealloc_counter = 0;


### PR DESCRIPTION
This is a significant design change as it prevents `indirect` from holding a object of a derived type of a non-copyable base class (if the base class were also non-movable then using `indirect` would be fine). Given the check on movability, we can still support moving `indirect<T>` when `T` is a non-movable type (like a mutex).

This change avoid allocation and makes `indirect` cheaper, which as a low-cost abstraction is the direction we want.