### PR TITLE
Extend indirect to work with std::format

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -720,7 +720,6 @@ Otherwise, the interface of the specialization is as defined in [optional].
 ```c++
 // [indirect.fmt]
 template <class T, class Alloc, class charT>
-  requires { std::formatter<T, char>{}; };
 struct std::formatter<indirect<T, Alloc>, charT> : std::formatter<T> {
   constexpr typename FormatContext::iterator parse(format_parse_context& ctx);
 
@@ -731,7 +730,9 @@ struct std::formatter<indirect<T, Alloc>, charT> : std::formatter<T> {
 ```
 
 Specialization of `std::formatter<indirect<T, Alloc>, charT>` when the underlying
-T support specialisation of `std::formatter<T, charT>`.
+T supports specialisation of `std::formatter<T, charT>`.
+
+* Preconditions: The specialization formatter<T, charT> meets the Formatter requirements.
 
 ## Feature-test Macro
 Add a new feature-test macro:

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -715,6 +715,24 @@ constexpr indirect<T, Alloc>& operator->() noexcept;
 
 Otherwise, the interface of the specialization is as defined in [optional].
 
+#### X.Y.13 Formatter support [indirect.fmt]
+
+```c++
+// [indirect.fmt]
+template <class T, class Alloc, class charT>
+  requires { std::formatter<T, char>{}; };
+struct std::formatter<indirect<T, Alloc>, charT> : std::formatter<T> {
+  constexpr typename FormatContext::iterator parse(format_parse_context& ctx);
+
+  template<class FormatContext>
+  typename FormatContext::iterator format(
+    indirect<T, Alloc> const& value, FormatContext& ctx) const;
+};
+```
+
+Specialization of `std::formatter<indirect<T, Alloc>, charT>` when the underlying
+T support specialisation of `std::formatter<T, charT>`.
+
 ### X.Z Class template polymorphic [polymorphic]
 
 #### X.Z.1 Class template polymorphic general [polymorphic.general]

--- a/indirect.h
+++ b/indirect.h
@@ -26,6 +26,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <memory>
 #include <utility>
 
+#if __has_include(<format>)
+#include <format>
+#endif
+
 namespace xyz {
 
 template <class T, class A>
@@ -342,5 +346,30 @@ struct std::hash<xyz::indirect<T, Alloc>> {
     return std::hash<typename xyz::indirect<T, Alloc>::value_type>{}(*key);
   }
 };
+
+#if (__cpp_lib_format >= 201907L)
+
+namespace xyz {
+
+template <class T>
+concept is_formattable = requires(T t) { std::formatter<T, char>; };
+
+}
+
+template <class T, class Alloc>
+  requires xyz::is_formattable<T>
+struct std::formatter<xyz::indirect<T, Alloc>> {
+  constexpr auto parse(format_parse_context& ctx)
+      -> format_parse_context::iterator {
+    return std::begin(ctx);
+  }
+
+  auto format(xyz::indirect<T, Alloc> const& value, format_context& ctx) const
+      -> format_context::iterator {
+    using namespace std::literals;
+    return std::format_to(ctx.out(), "{}", *value);
+  }
+};
+#endif
 
 #endif  // XYZ_INDIRECT_H

--- a/indirect.h
+++ b/indirect.h
@@ -352,24 +352,27 @@ struct std::hash<xyz::indirect<T, Alloc>> {
 namespace xyz {
 
 template <class T>
-concept is_formattable = requires(T t) { std::formatter<T, char>; };
-
+concept is_formattable = requires(T t) { std::formatter<T, char>{}; };
+    
 }
 
-template <class T, class Alloc>
+template <class T, class Alloc, class charT>
   requires xyz::is_formattable<T>
-struct std::formatter<xyz::indirect<T, Alloc>> {
+struct std::formatter<xyz::indirect<T, Alloc>, charT> : std::formatter<T> {
   constexpr auto parse(format_parse_context& ctx)
       -> format_parse_context::iterator {
-    return std::begin(ctx);
+    return std::formatter<T>::parse(ctx);
   }
 
-  auto format(xyz::indirect<T, Alloc> const& value, format_context& ctx) const
-      -> format_context::iterator {
-    using namespace std::literals;
-    return std::format_to(ctx.out(), "{}", *value);
+  template<class FormatContext>
+  auto format(xyz::indirect<T, Alloc> const& value, FormatContext& ctx) const
+      -> typename FormatContext::iterator {
+//    using namespace std::literals;
+//    return std::format_to(ctx.out(), "{}", *value);
+    return std::formatter<T>::format(*value, ctx);
   }
 };
+
 #endif // __cpp_lib_format >= 201907L
 
 #endif  // XYZ_INDIRECT_H

--- a/indirect.h
+++ b/indirect.h
@@ -370,6 +370,6 @@ struct std::formatter<xyz::indirect<T, Alloc>> {
     return std::format_to(ctx.out(), "{}", *value);
   }
 };
-#endif
+#endif // __cpp_lib_format >= 201907L
 
 #endif  // XYZ_INDIRECT_H

--- a/indirect.h
+++ b/indirect.h
@@ -367,8 +367,6 @@ struct std::formatter<xyz::indirect<T, Alloc>, charT> : std::formatter<T> {
   template<class FormatContext>
   auto format(xyz::indirect<T, Alloc> const& value, FormatContext& ctx) const
       -> typename FormatContext::iterator {
-//    using namespace std::literals;
-//    return std::format_to(ctx.out(), "{}", *value);
     return std::formatter<T>::format(*value, ctx);
   }
 };

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -647,4 +647,23 @@ TEST(IndirectTest, HashCustomAllocator) {
   EXPECT_EQ(std::hash<IndirectType>()(a), std::hash<int>()(*a));
 }
 #endif  // (__cpp_lib_memory_resource >= 201603L)
+
+#if (__cpp_lib_format >= 201907L)
+
+TEST(IndirectTest, FormatNativeTypesDefaultFormatting) {
+  EXPECT_EQ(std::format("{}", xyz::indirect<bool>(std::in_place, true)), "true");
+  EXPECT_EQ(std::format("{}", xyz::indirect<int>(std::in_place, 100)), "100");
+  EXPECT_EQ(std::format("{}", xyz::indirect<float>(std::in_place, 50.0f)), "50");
+  EXPECT_EQ(std::format("{}", xyz::indirect<double>(std::in_place, 25.0)), "25");
+}
+
+TEST(IndirectTest, FormatNativeTypesPropagateFormatting) {
+  EXPECT_EQ(std::format("{:*<6}", xyz::indirect<bool>(std::in_place, true)), "true**");
+  EXPECT_EQ(std::format("{:*^7}", xyz::indirect<int>(std::in_place, 100)), "**100**");
+  EXPECT_EQ(std::format("{:>7}", xyz::indirect<float>(std::in_place, 50.0f)), "     50");
+  EXPECT_EQ(std::format("{:+8.3e}", xyz::indirect<double>(std::in_place, 25.75)), "+2.575e+01");
+}
+
+#endif  // __cpp_lib_format >= 201907L
+
 }  // namespace


### PR DESCRIPTION
Initial draft, will push up tests and add to the spec shortly.