### PR TITLE
Fixes for incomplete type support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,6 +42,11 @@ jobs:
               compiler: { type: VISUAL, version: 16, cc: "cl", cxx: "cl" },
             }
           - {
+              name: "Visual Studio 2022",
+              os: windows-latest,
+              compiler: { type: VISUAL, version: 17, cc: "cl", cxx: "cl" },
+            }
+          - {
               name: "MacOS Apple Clang 14",
               os: macos-13,
               compiler:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,12 +14,12 @@ cc_library(
 
 cc_library(
     name = "polymorphic_inline_vtable",
-    defines = ["XYZ_POLYMORPHIC_USES_EXPERIMENTAL_INLINE_VTABLE"],
     hdrs = [
         "experimental/polymorphic_inline_vtable.h",
         "polymorphic.h",
     ],
     copts = ["-Iexternal/value_types/"],
+    defines = ["XYZ_POLYMORPHIC_USES_EXPERIMENTAL_INLINE_VTABLE"],
 )
 
 cc_test(
@@ -105,6 +105,7 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
 cc_library(
     name = "polymorphic_consteval_inline_vtable",
     srcs = ["polymorphic_consteval.cc"],
@@ -129,4 +130,28 @@ cc_binary(
         ":polymorphic_inline_vtable",
         "@com_google_benchmark//:benchmark_main",
     ],
+)
+
+cc_library(
+    name = "indirect_pimpl",
+    srcs = ["indirect_pimpl.cc"],
+    hdrs = ["indirect_pimpl.h"],
+    deps = ["indirect"],
+)
+
+build_test(
+    name = "indirect_pimpl_build_test",
+    targets = ["indirect_pimpl"],
+)
+
+cc_library(
+    name = "polymorphic_pimpl",
+    srcs = ["polymorphic_pimpl.cc"],
+    hdrs = ["polymorphic_pimpl.h"],
+    deps = ["polymorphic"],
+)
+
+build_test(
+    name = "polymorphic_pimpl_build_test",
+    targets = ["polymorphic_pimpl"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -134,7 +134,10 @@ cc_binary(
 
 cc_library(
     name = "indirect_pimpl",
-    srcs = ["indirect_pimpl.cc"],
+    srcs = [
+        "indirect_pimpl.cc",
+        "indirect_pimpl_use.cc",
+    ],
     hdrs = ["indirect_pimpl.h"],
     deps = ["indirect"],
 )
@@ -146,7 +149,10 @@ build_test(
 
 cc_library(
     name = "polymorphic_pimpl",
-    srcs = ["polymorphic_pimpl.cc"],
+    srcs = [
+        "polymorphic_pimpl.cc",
+        "polymorphic_pimpl_use.cc",
+    ],
     hdrs = ["polymorphic_pimpl.h"],
     deps = ["polymorphic"],
 )

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -355,6 +355,8 @@ struct hash<indirect<T, Alloc>>;
 indirect()
 ```
 
+* _Mandates_: `is_default_constructible_v<T>` is true.
+
 * _Effects_: Constructs an indirect owning a default constructed `T`.
 
 * _Postconditions_: `*this` is not valueless.
@@ -390,6 +392,8 @@ constexpr indirect(
 constexpr indirect(const indirect& other);
 ```
 
+* _Mandates_: `is_copy_constructible_v<T>` is true.
+
 * _Preconditions_: `other` is not valueless.
 
 * _Effects_: Constructs an indirect owning an instance of `T` created with the
@@ -401,6 +405,8 @@ constexpr indirect(const indirect& other);
 constexpr indirect(
   std::allocator_arg_t, const Allocator& alloc, const indirect& other);
 ```
+
+* _Mandates_: `is_copy_constructible_v<T>` is true.
 
 * _Preconditions_: `other` is not valueless and `Allocator` meets the
   _Cpp17Allocator_ requirements.
@@ -428,8 +434,6 @@ constexpr indirect(
   std::allocator_arg_t, const Allocator& alloc, indirect&& other) noexcept;
 ```
 
-* _Constraints_: `is_copy_constructible_v<T>` is true.
-
 * _Preconditions_: `other` is not valueless and `Allocator` meets the
   _Cpp17Allocator_ requirements.
 
@@ -454,6 +458,8 @@ constexpr ~indirect();
 ```c++
 constexpr indirect& operator=(const indirect& other);
 ```
+
+* _Mandates_: `is_copy_constructible_v<T>` is true.
 
 * _Preconditions_: `other` is not valueless.
 
@@ -800,7 +806,7 @@ class polymorphic {
 polymorphic()
 ```
 
-* _Constraints_: `is_default_constructible_v<T>` is true,
+* _Mandates_: `is_default_constructible_v<T>` is true,
   `is_copy_constructible_v<T>` is true.
 
 * _Effects_: Constructs a polymorphic owning a default constructed `T`.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1259,8 +1259,7 @@ void Class::do_something() {
 // Class.h
 
 class Class {
-  class Impl;
-  indirect<Impl> impl_;
+  indirect<class Impl> impl_;
  public:
   Class();
   ~Class();

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -355,8 +355,6 @@ struct hash<indirect<T, Alloc>>;
 indirect()
 ```
 
-* _Constraints_: `is_default_constructible_v<T>` is true.
-
 * _Effects_: Constructs an indirect owning a default constructed `T`.
 
 * _Postconditions_: `*this` is not valueless.
@@ -392,8 +390,6 @@ constexpr indirect(
 constexpr indirect(const indirect& other);
 ```
 
-* _Constraints_: `is_copy_constructible_v<T>` is true.
-
 * _Preconditions_: `other` is not valueless.
 
 * _Effects_: Constructs an indirect owning an instance of `T` created with the
@@ -405,8 +401,6 @@ constexpr indirect(const indirect& other);
 constexpr indirect(
   std::allocator_arg_t, const Allocator& alloc, const indirect& other);
 ```
-
-* _Constraints_: `is_copy_constructible_v<T>` is true.
 
 * _Preconditions_: `other` is not valueless and `Allocator` meets the
   _Cpp17Allocator_ requirements.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1218,8 +1218,8 @@ class Class {
   ~Class();
   Class(const Class&);
   Class& operator=(const Class&);
-  Class(Class&&) noexcept = default;
-  Class& operator=(Class&&) noexcept = default;
+  Class(Class&&) noexcept;
+  Class& operator=(Class&&) noexcept;
   
   void do_something();
 };
@@ -1248,6 +1248,9 @@ Class& Class::operator=(const Class& other) {
   return *this;
 }
 
+Class(Class&&) noexcept = default;
+Class& operator=(Class&&) noexcept = default;
+
 void Class::do_something() {
   impl_->do_something();
 }
@@ -1265,8 +1268,8 @@ class Class {
   ~Class();
   Class(const Class&);
   Class& operator=(const Class&);
-  Class(Class&&) noexcept = default;
-  Class& operator=(Class&&) noexcept = default;
+  Class(Class&&) noexcept;
+  Class& operator=(Class&&) noexcept;
   
   void do_something();
 };
@@ -1284,6 +1287,8 @@ Class::Class() : impl_(indirect<Impl>()) {}
 Class::~Class() = default;
 Class::Class(const Class&) = default;
 Class& Class::operator=(const Class&) = default;
+Class(Class&&) noexcept = default;
+Class& operator=(Class&&) noexcept = default;
 
 void Class::do_something() {
   impl_->do_something();

--- a/indirect.h
+++ b/indirect.h
@@ -58,9 +58,7 @@ class indirect {
   using value_type = T;
   using allocator_type = A;
 
-  constexpr indirect()
-    requires std::default_initializable<T>
-  {
+  constexpr indirect() {
     T* mem = allocator_traits::allocate(alloc_, 1);
     try {
       allocator_traits::construct(alloc_, mem);
@@ -101,7 +99,6 @@ class indirect {
   }
 
   constexpr indirect(const indirect& other)
-    requires std::copy_constructible<T>
       : alloc_(allocator_traits::select_on_container_copy_construction(
             other.alloc_)) {
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
@@ -117,7 +114,6 @@ class indirect {
 
   constexpr indirect(std::allocator_arg_t, const A& alloc,
                      const indirect& other)
-    requires std::copy_constructible<T>
       : alloc_(alloc) {
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     T* mem = allocator_traits::allocate(alloc_, 1);
@@ -146,7 +142,6 @@ class indirect {
   constexpr ~indirect() { reset(); }
 
   constexpr indirect& operator=(const indirect& other)
-    requires std::copy_constructible<T>
   {
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     if (this != &other) {
@@ -356,7 +351,8 @@ concept is_formattable = requires(T t) { std::formatter<T, charT>{}; };
 
 template <class T, class Alloc, class charT>
   requires xyz::is_formattable<T, charT>
-struct std::formatter<xyz::indirect<T, Alloc>, charT> : std::formatter<T, charT> {
+struct std::formatter<xyz::indirect<T, Alloc>, charT>
+    : std::formatter<T, charT> {
   template <class ParseContext>
   constexpr auto parse(ParseContext& ctx) -> typename ParseContext::iterator {
     return std::formatter<T, charT>::parse(ctx);

--- a/indirect.h
+++ b/indirect.h
@@ -118,6 +118,7 @@ class indirect {
   constexpr indirect(std::allocator_arg_t, const A& alloc,
                      const indirect& other)
       : alloc_(alloc) {
+    static_assert(std::is_copy_constructible_v<T>);
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     T* mem = allocator_traits::allocate(alloc_, 1);
     try {

--- a/indirect.h
+++ b/indirect.h
@@ -25,6 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <compare>
 #include <concepts>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 #if __has_include(<format>)
@@ -59,6 +60,7 @@ class indirect {
   using allocator_type = A;
 
   constexpr indirect() {
+    static_assert(std::is_default_constructible_v<T>);
     T* mem = allocator_traits::allocate(alloc_, 1);
     try {
       allocator_traits::construct(alloc_, mem);
@@ -101,6 +103,7 @@ class indirect {
   constexpr indirect(const indirect& other)
       : alloc_(allocator_traits::select_on_container_copy_construction(
             other.alloc_)) {
+    static_assert(std::is_copy_constructible_v<T>);
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     T* mem = allocator_traits::allocate(alloc_, 1);
     try {
@@ -141,8 +144,8 @@ class indirect {
 
   constexpr ~indirect() { reset(); }
 
-  constexpr indirect& operator=(const indirect& other)
-  {
+  constexpr indirect& operator=(const indirect& other) {
+    static_assert(std::is_copy_constructible_v<T>);
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     if (this != &other) {
       if constexpr (std::is_copy_assignable_v<T>) {

--- a/indirect_pimpl.cc
+++ b/indirect_pimpl.cc
@@ -14,3 +14,12 @@ Class& Class::operator=(const Class&) = default;
 
 void Class::do_something() { impl_->do_something(); }
 }  //  namespace xyz::testing
+
+void check_methods() {
+  xyz::testing::Class c; // Default construction.
+  auto cc = c; // Copy construction.
+  auto mc = std::move(c); // Move construction.
+  c = cc; // Copy assignment.
+  c = xyz::testing::Class(); // Move assignment.
+  c.do_something();
+}

--- a/indirect_pimpl.cc
+++ b/indirect_pimpl.cc
@@ -1,0 +1,16 @@
+#include "indirect_pimpl.h"
+
+namespace xyz::testing {
+
+class Impl {
+ public:
+  void do_something();
+};
+
+Class::Class() : impl_(xyz::indirect<Impl>()) {}
+Class::~Class() = default;
+Class::Class(const Class&) = default;
+Class& Class::operator=(const Class&) = default;
+
+void Class::do_something() { impl_->do_something(); }
+}  //  namespace xyz::testing

--- a/indirect_pimpl.cc
+++ b/indirect_pimpl.cc
@@ -11,15 +11,17 @@ Class::Class() : impl_(xyz::indirect<Impl>()) {}
 Class::~Class() = default;
 Class::Class(const Class&) = default;
 Class& Class::operator=(const Class&) = default;
+Class::Class(Class&&) noexcept = default;
+Class& Class::operator=(Class&&) noexcept = default;
 
 void Class::do_something() { impl_->do_something(); }
 }  //  namespace xyz::testing
 
 void check_methods() {
-  xyz::testing::Class c; // Default construction.
-  auto cc = c; // Copy construction.
-  auto mc = std::move(c); // Move construction.
-  c = cc; // Copy assignment.
-  c = xyz::testing::Class(); // Move assignment.
+  xyz::testing::Class c;      // Default construction.
+  auto cc = c;                // Copy construction.
+  auto mc = std::move(c);     // Move construction.
+  c = cc;                     // Copy assignment.
+  c = xyz::testing::Class();  // Move assignment.
   c.do_something();
 }

--- a/indirect_pimpl.h
+++ b/indirect_pimpl.h
@@ -1,0 +1,16 @@
+#include "indirect.h"
+namespace xyz::testing {
+class Class {
+  indirect<class Impl> impl_;
+
+ public:
+  Class();
+  ~Class();
+  Class(const Class&);
+  Class& operator=(const Class&);
+  Class(Class&&) noexcept = default;
+  Class& operator=(Class&&) noexcept = default;
+
+  void do_something();
+};
+}  // namespace xyz::testing

--- a/indirect_pimpl.h
+++ b/indirect_pimpl.h
@@ -8,8 +8,8 @@ class Class {
   ~Class();
   Class(const Class&);
   Class& operator=(const Class&);
-  Class(Class&&) noexcept = default;
-  Class& operator=(Class&&) noexcept = default;
+  Class(Class&&) noexcept;
+  Class& operator=(Class&&) noexcept;
 
   void do_something();
 };

--- a/indirect_pimpl_use.cc
+++ b/indirect_pimpl_use.cc
@@ -1,0 +1,12 @@
+#include "indirect_pimpl.h"
+
+namespace xyz::testing {
+void check_methods() {
+  xyz::testing::Class c;      // Default construction.
+  auto cc = c;                // Copy construction.
+  auto mc = std::move(c);     // Move construction.
+  c = cc;                     // Copy assignment.
+  c = xyz::testing::Class();  // Move assignment.
+  c.do_something();
+}
+}  // namespace xyz::testing

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -97,7 +97,6 @@ class polymorphic {
   using allocator_type = A;
 
   constexpr polymorphic()
-    requires std::default_initializable<T>
   {
     using cb_allocator = typename std::allocator_traits<
         A>::template rebind_alloc<detail::direct_control_block<T, T, A>>;

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -96,8 +96,8 @@ class polymorphic {
   using value_type = T;
   using allocator_type = A;
 
-  constexpr polymorphic()
-  {
+  constexpr polymorphic() {
+    static_assert(std::is_default_constructible_v<T>);
     using cb_allocator = typename std::allocator_traits<
         A>::template rebind_alloc<detail::direct_control_block<T, T, A>>;
     using cb_traits = std::allocator_traits<cb_allocator>;

--- a/polymorphic_pimpl.cc
+++ b/polymorphic_pimpl.cc
@@ -20,3 +20,12 @@ ClassWithPolymorphicPimpl& ClassWithPolymorphicPimpl::operator=(
 
 void ClassWithPolymorphicPimpl::do_something() { impl_->do_something(); }
 }  //  namespace xyz::testing
+
+void check_methods() {
+  xyz::testing::ClassWithPolymorphicPimpl c; // Default construction.
+  auto cc = c; // Copy construction.
+  auto mc = std::move(c); // Move construction.
+  c = cc; // Copy assignment.
+  c = xyz::testing::ClassWithPolymorphicPimpl(); // Move assignment.
+  c.do_something();
+}

--- a/polymorphic_pimpl.cc
+++ b/polymorphic_pimpl.cc
@@ -1,0 +1,22 @@
+#include "polymorphic_pimpl.h"
+
+namespace xyz::testing {
+
+class Impl {
+ public:
+  void do_something();
+};
+
+ClassWithPolymorphicPimpl::ClassWithPolymorphicPimpl()
+    : impl_(xyz::polymorphic<Impl>()) {}
+
+ClassWithPolymorphicPimpl::~ClassWithPolymorphicPimpl() = default;
+
+ClassWithPolymorphicPimpl::ClassWithPolymorphicPimpl(
+    const ClassWithPolymorphicPimpl&) = default;
+
+ClassWithPolymorphicPimpl& ClassWithPolymorphicPimpl::operator=(
+    const ClassWithPolymorphicPimpl&) = default;
+
+void ClassWithPolymorphicPimpl::do_something() { impl_->do_something(); }
+}  //  namespace xyz::testing

--- a/polymorphic_pimpl.cc
+++ b/polymorphic_pimpl.cc
@@ -18,14 +18,11 @@ ClassWithPolymorphicPimpl::ClassWithPolymorphicPimpl(
 ClassWithPolymorphicPimpl& ClassWithPolymorphicPimpl::operator=(
     const ClassWithPolymorphicPimpl&) = default;
 
+ClassWithPolymorphicPimpl::ClassWithPolymorphicPimpl(
+    ClassWithPolymorphicPimpl&&) noexcept = default;
+
+ClassWithPolymorphicPimpl& ClassWithPolymorphicPimpl::operator=(
+    ClassWithPolymorphicPimpl&&) noexcept = default;
+
 void ClassWithPolymorphicPimpl::do_something() { impl_->do_something(); }
 }  //  namespace xyz::testing
-
-void check_methods() {
-  xyz::testing::ClassWithPolymorphicPimpl c; // Default construction.
-  auto cc = c; // Copy construction.
-  auto mc = std::move(c); // Move construction.
-  c = cc; // Copy assignment.
-  c = xyz::testing::ClassWithPolymorphicPimpl(); // Move assignment.
-  c.do_something();
-}

--- a/polymorphic_pimpl.h
+++ b/polymorphic_pimpl.h
@@ -9,9 +9,8 @@ class ClassWithPolymorphicPimpl {
   ~ClassWithPolymorphicPimpl();
   ClassWithPolymorphicPimpl(const ClassWithPolymorphicPimpl&);
   ClassWithPolymorphicPimpl& operator=(const ClassWithPolymorphicPimpl&);
-  ClassWithPolymorphicPimpl(ClassWithPolymorphicPimpl&&) noexcept = default;
-  ClassWithPolymorphicPimpl& operator=(ClassWithPolymorphicPimpl&&) noexcept =
-      default;
+  ClassWithPolymorphicPimpl(ClassWithPolymorphicPimpl&&) noexcept;
+  ClassWithPolymorphicPimpl& operator=(ClassWithPolymorphicPimpl&&) noexcept;
 
   void do_something();
 };

--- a/polymorphic_pimpl.h
+++ b/polymorphic_pimpl.h
@@ -1,0 +1,18 @@
+#include "polymorphic.h"
+
+namespace xyz::testing {
+class ClassWithPolymorphicPimpl {
+  polymorphic<class Impl> impl_;
+
+ public:
+  ClassWithPolymorphicPimpl();
+  ~ClassWithPolymorphicPimpl();
+  ClassWithPolymorphicPimpl(const ClassWithPolymorphicPimpl&);
+  ClassWithPolymorphicPimpl& operator=(const ClassWithPolymorphicPimpl&);
+  ClassWithPolymorphicPimpl(ClassWithPolymorphicPimpl&&) noexcept = default;
+  ClassWithPolymorphicPimpl& operator=(ClassWithPolymorphicPimpl&&) noexcept =
+      default;
+
+  void do_something();
+};
+}  // namespace xyz::testing

--- a/polymorphic_pimpl_use.cc
+++ b/polymorphic_pimpl_use.cc
@@ -1,0 +1,12 @@
+#include "polymorphic_pimpl.h"
+
+namespace xyz::testing{
+void check_methods() {
+  xyz::testing::ClassWithPolymorphicPimpl c; // Default construction.
+  auto cc = c; // Copy construction.
+  auto mc = std::move(c); // Move construction.
+  c = cc; // Copy assignment.
+  c = xyz::testing::ClassWithPolymorphicPimpl(); // Move assignment.
+  c.do_something();
+}
+} // namespace xyz::testing


### PR DESCRIPTION
Add tests for compiling with incomplete types.

Update Draft and headers: some requires clauses need to be static_asserts to support incomplete types.

See: https://timsong-cpp.github.io/cppwp/n4861/structure for the difference between _Constraints_ and _Mandates_.

Thanks to Bengt Gustaffson for pointing out the need for these changes.