### PR TITLE
Definine a devcontainer with docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,14 +4,14 @@
 FROM ubuntu:22.04
  
 # Install gcc, clang and some supporting tools for downloading/installing later tools.
-#RUN apt-get update && apt-get install -y wget g++ lcov llvm gcov git ninja-build software-properties-common unzip
+RUN apt-get update && apt-get install -y wget g++ lcov llvm git gpg ninja-build software-properties-common unzip
 
 # Install newer CMake from kitware.
-#RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-#RUN apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' && apt-get update && apt-get install -y cmake
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+&& apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' && apt-get update && apt-get install -y cmake
 
 # Install bazel.
-#RUN wget https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh \
-#&& bash bazel-6.4.0-installer-linux-x86_64.sh && rm bazel-6.4.0-installer-linux-x86_64.sh
+RUN wget https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh \
+&& bash bazel-6.4.0-installer-linux-x86_64.sh && rm bazel-6.4.0-installer-linux-x86_64.sh
 
 ENV PATH="/usr/local/bin:$PATH"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Your Name <your@email.com>"
 ENV DEBIAN_FRONTEND=noninteractive
  
 # Install gcc, clang, bazel and cmake
-RUN apt-get update && apt-get install -y gcc llvm ninja-build && \
+RUN apt-get update && apt-get install -y snap curl gcc llvm ninja-build && \
 curl --proto '=https' https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh | sh && \
 snap install cmake –classic
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Your Name <your@email.com>"
 ENV DEBIAN_FRONTEND=noninteractive
  
 # Install gcc, clang, bazel and cmake
-RUN apt-get update && apt-get install -y snap curl gcc llvm ninja-build && \
+RUN apt-get update && apt-get install -y snapd curl gcc llvm ninja-build && \
 curl --proto '=https' https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh | sh && \
 snap install cmake –classic
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,5 +7,8 @@ FROM ubuntu:22.04
 LABEL maintainer="Your Name <your@email.com>"
  
 # Install gcc, clang, bazel and cmake
-RUN apt-get update && apt-get install -y curl gcc llvm ninja-build
-RUN curl --proto '=https' https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh | sh
+RUN apt-get update && apt-get install -y wget g++ llvm ninja-build unzip
+RUN wget https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh \
+&& bash bazel-6.4.0-installer-linux-x86_64.sh && rm bazel-6.4.0-installer-linux-x86_64.sh
+
+RUN PATH="/usr/local/bin:$PATH"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,8 +10,8 @@ LABEL maintainer="Your Name <your@email.com>"
 ENV DEBIAN_FRONTEND=noninteractive
  
 # Install gcc, clang, bazel and cmake
-RUN apt-get update && apt-get install -y curl gcc llvm ninja-build && \
-curl --proto '=https' https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh | sh && \
+RUN apt-get update && apt-get install -y curl gcc llvm ninja-build
+RUN curl --proto '=https' https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh | sh
 
 # Create a volume
 VOLUME /dev

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,14 +4,14 @@
 FROM ubuntu:22.04
  
 # Install gcc, clang and some supporting tools for downloading/installing later tools.
-RUN apt update && apt install -y wget g++ lcov llvm gcov git ninja-build software-properties-common unzip
+#RUN apt-get update && apt-get install -y wget g++ lcov llvm gcov git ninja-build software-properties-common unzip
 
 # Install newer CMake from kitware.
 #RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-#RUN apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' && apt update && apt install -y cmake
+#RUN apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' && apt-get update && apt-get install -y cmake
 
 # Install bazel.
-RUN wget https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh \
-&& bash bazel-6.4.0-installer-linux-x86_64.sh && rm bazel-6.4.0-installer-linux-x86_64.sh
+#RUN wget https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh \
+#&& bash bazel-6.4.0-installer-linux-x86_64.sh && rm bazel-6.4.0-installer-linux-x86_64.sh
 
-RUN PATH="/usr/local/bin:$PATH"
+ENV PATH="/usr/local/bin:$PATH"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,9 +10,8 @@ LABEL maintainer="Your Name <your@email.com>"
 ENV DEBIAN_FRONTEND=noninteractive
  
 # Install gcc, clang, bazel and cmake
-RUN apt-get update && apt-get install -y snapd curl gcc llvm ninja-build && \
+RUN apt-get update && apt-get install -y curl gcc llvm ninja-build && \
 curl --proto '=https' https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh | sh && \
-snap install cmake –classic
 
 # Create a volume
 VOLUME /dev

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for Ubuntu 22.04 with C++ development tools installed
+ 
+# Set the base image
+FROM ubuntu:22.04
+ 
+# Maintainer
+LABEL maintainer="Your Name <your@email.com>"
+ 
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ 
+# Install gcc, clang, bazel and cmake
+RUN apt-get update && apt-get install -y gcc llvm ninja-build && \
+curl --proto '=https' https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh | sh && \
+snap install cmake –classic
+
+# Create a volume
+VOLUME /dev
+ 
+# Set the working directory
+WORKDIR /dev
+ 
+# Run the command on container startup
+CMD ["/bin/bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,10 +10,8 @@ LABEL maintainer="Your Name <your@email.com>"
 RUN apt update && apt install -y wget g++ lcov llvm gcov git ninja-build software-properties-common unzip
 
 # Install newer CMake from kitware.
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
-&& apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' \
-&& apt update \
-&& apt install -y cmake
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' && apt update && apt install -y cmake
 
 # Install bazel.
 RUN wget https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,21 @@
-# Dockerfile for Ubuntu 22.04 with C++ development tools installed
+# Dockerfile for Ubuntu 22.04 with extra C++ development tools.
  
-# Set the base image
+# Set the base image.
 FROM ubuntu:22.04
  
 # Maintainer
 LABEL maintainer="Your Name <your@email.com>"
  
-# Install gcc, clang, bazel and cmake
-RUN apt-get update && apt-get install -y wget g++ llvm ninja-build unzip
+# Install gcc, clang and some supporting tools for downloading/installing later tools.
+RUN apt update && apt install -y wget g++ llvm ninja-build software-properties-common unzip
+
+# Install newer CMake from kitware.
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+&& apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' \
+&& apt update \
+&& apt install -y cmake
+
+# Install bazel.
 RUN wget https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh \
 && bash bazel-6.4.0-installer-linux-x86_64.sh && rm bazel-6.4.0-installer-linux-x86_64.sh
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,14 @@
-# Dockerfile for Ubuntu 22.04 with extra C++ development tools.
+# Dockerfile for Ubuntu 22.04 with C++ development tools.
  
 # Set the base image.
 FROM ubuntu:22.04
- 
-# Maintainer
-LABEL maintainer="Your Name <your@email.com>"
  
 # Install gcc, clang and some supporting tools for downloading/installing later tools.
 RUN apt update && apt install -y wget g++ lcov llvm gcov git ninja-build software-properties-common unzip
 
 # Install newer CMake from kitware.
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-RUN apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' && apt update && apt install -y cmake
+#RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+#RUN apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' && apt update && apt install -y cmake
 
 # Install bazel.
 RUN wget https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,18 +6,6 @@ FROM ubuntu:22.04
 # Maintainer
 LABEL maintainer="Your Name <your@email.com>"
  
-# Set environment variables
-ENV DEBIAN_FRONTEND=noninteractive
- 
 # Install gcc, clang, bazel and cmake
 RUN apt-get update && apt-get install -y curl gcc llvm ninja-build
 RUN curl --proto '=https' https://github.com/bazelbuild/bazel/releases/download/6.4.0/bazel-6.4.0-installer-linux-x86_64.sh | sh
-
-# Create a volume
-VOLUME /dev
- 
-# Set the working directory
-WORKDIR /dev
- 
-# Run the command on container startup
-CMD ["/bin/bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:22.04
 LABEL maintainer="Your Name <your@email.com>"
  
 # Install gcc, clang and some supporting tools for downloading/installing later tools.
-RUN apt update && apt install -y wget g++ llvm ninja-build software-properties-common unzip
+RUN apt update && apt install -y wget g++ lcov llvm gcov git ninja-build software-properties-common unzip
 
 # Install newer CMake from kitware.
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+}


### PR DESCRIPTION
Devcontainer means users can press '.' on our github page and start up VS Code in-browser.

Opening a terminal will fire up a Docker-backed container instance with developer tools installed to build code and run tests with CMake and Bazel.