### PR TITLE
Fix for compile error in SBO impl

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -522,9 +522,7 @@ constexpr bool valueless_after_move() const noexcept;
 constexpr allocator_type get_allocator() const noexcept;
 ```
 
-* _Returns_: A copy of the Allocator object used to construct this object
-  or, if that allocator has been replaced, a copy of the most recent
-  replacement.
+* _Returns_: A copy of the Allocator object used to construct the owned object.
 
 #### X.Y.7 Swap [indirect.swap]
 
@@ -973,9 +971,7 @@ constexpr bool valueless_after_move() const noexcept;
 constexpr allocator_type get_allocator() const noexcept;
 ```
 
-* _Returns_: A copy of the Allocator object used to construct this object
-  or, if that allocator has been replaced, a copy of the most recent
-  replacement.
+* _Returns_: A copy of the Allocator object used to construct the owned object.
 
 #### X.Z.7 Swap [polymorphic.swap]
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -522,7 +522,7 @@ constexpr bool valueless_after_move() const noexcept;
 constexpr allocator_type get_allocator() const noexcept;
 ```
 
-* _Returns_: A copy of the Allocator object used to construct the owned object
+* _Returns_: A copy of the Allocator object used to construct this object
   or, if that allocator has been replaced, a copy of the most recent
   replacement.
 
@@ -973,7 +973,7 @@ constexpr bool valueless_after_move() const noexcept;
 constexpr allocator_type get_allocator() const noexcept;
 ```
 
-* _Returns_: A copy of the Allocator object used to construct the owned object
+* _Returns_: A copy of the Allocator object used to construct this object
   or, if that allocator has been replaced, a copy of the most recent
   replacement.
 

--- a/experimental/polymorphic_sbo.h
+++ b/experimental/polymorphic_sbo.h
@@ -50,8 +50,6 @@ constexpr bool is_sbo_compatible() {
 
 template <class T, class A>
 struct control_block {
-  using allocator_type = A;
-
   virtual constexpr T* ptr() noexcept = 0;
   virtual constexpr ~control_block() = default;
   virtual constexpr void destroy(A& alloc) = 0;

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -41,6 +41,7 @@ class Base {
   virtual int value() const = 0;
   virtual void set_value(int) = 0;
 };
+
 class Derived_NoSBO : public Base, public xyz::NoPolymorphicSBO {
  private:
   int value_;
@@ -777,9 +778,6 @@ TEST(PolymorphicTest, MultipleBases) {
 }
 
 #if (__cpp_lib_memory_resource >= 201603L)
-// TODO: Fix compilation issues with pmr allocators and SBO.
-// https://github.com/jbcoe/value_types/issues/112
-#ifndef XYZ_POLYMORPHIC_USES_EXPERIMENTAL_SMALL_BUFFER_OPTIMIZATION
 TEST(PolymorphicTest, InteractionWithPMRAllocators) {
   std::array<std::byte, 1024> buffer;
   std::pmr::monotonic_buffer_resource mbr{buffer.data(), buffer.size()};
@@ -806,7 +804,6 @@ TEST(PolymorphicTest, InteractionWithPMRAllocatorsWhenCopyThrows) {
   std::pmr::vector<PolymorphicType> values{pa};
   EXPECT_THROW(values.push_back(a), ThrowsOnCopyConstruction::Exception);
 }
-#endif  // XYZ_POLYMORPHIC_USES_EXPERIMENTAL_SMALL_BUFFER_OPTIMIZATION
 #endif  // (__cpp_lib_memory_resource >= 201603L)
 
 }  // namespace


### PR DESCRIPTION
control_block was unintentionally made allocator_aware.

Thanks to Nina Ranns and Josh Berne

Fixes #112 