### PR TITLE
Add clang-format check to github actions

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -9,5 +9,5 @@ jobs:
     - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.11.0
       with:
-        clang-format-version: '13'
+        clang-format-version: '17'
         check-path: ''

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,13 @@
+name: clang-format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '13'
+        check-path: ''

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -9,5 +9,5 @@ jobs:
     - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.11.0
       with:
-        clang-format-version: '17.0.4'
+        clang-format-version: '17'
         check-path: ''

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -9,5 +9,5 @@ jobs:
     - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.11.0
       with:
-        clang-format-version: '17'
+        clang-format-version: '17.0.4'
         check-path: ''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,4 @@ repos:
     rev: v17.0.4
     hooks:
     -   id: clang-format
+        types_or: [c++, c]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,7 @@ repos:
     -   id: forbid-submodules
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.4
+    hooks:
+    -   id: clang-format

--- a/benchmarks/polymorphic_benchmark.cc
+++ b/benchmarks/polymorphic_benchmark.cc
@@ -155,7 +155,8 @@ static void Polymorphic_BM_ArrayCopy_RawPointer(benchmark::State& state) {
   }
 }
 
-static void Polymorphic_BM_VectorAccumulate_RawPointer(benchmark::State& state) {
+static void Polymorphic_BM_VectorAccumulate_RawPointer(
+    benchmark::State& state) {
   std::vector<Base*> v(LARGE_VECTOR_SIZE);
   for (size_t i = 0; i < LARGE_VECTOR_SIZE; ++i) {
     if (i % 2 == 0) {

--- a/compile_checks/indirect_consteval.cc
+++ b/compile_checks/indirect_consteval.cc
@@ -28,7 +28,8 @@ struct ConstexprHashable {};
 }  // namespace xyz::testing
 template <>
 struct std::hash<xyz::testing::ConstexprHashable> {
-  constexpr std::size_t operator()(const xyz::testing::ConstexprHashable& key) const {
+  constexpr std::size_t operator()(
+      const xyz::testing::ConstexprHashable& key) const {
     return 0;
   }
 };

--- a/compile_checks/polymorphic_pimpl_use.cc
+++ b/compile_checks/polymorphic_pimpl_use.cc
@@ -1,12 +1,12 @@
 #include "polymorphic_pimpl.h"
 
-namespace xyz::testing{
+namespace xyz::testing {
 void check_methods() {
-  xyz::testing::ClassWithPolymorphicPimpl c; // Default construction.
-  auto cc = c; // Copy construction.
-  auto mc = std::move(c); // Move construction.
-  c = cc; // Copy assignment.
-  c = xyz::testing::ClassWithPolymorphicPimpl(); // Move assignment.
+  xyz::testing::ClassWithPolymorphicPimpl c;      // Default construction.
+  auto cc = c;                                    // Copy construction.
+  auto mc = std::move(c);                         // Move construction.
+  c = cc;                                         // Copy assignment.
+  c = xyz::testing::ClassWithPolymorphicPimpl();  // Move assignment.
   c.do_something();
 }
-} // namespace xyz::testing
+}  // namespace xyz::testing

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -42,3 +42,10 @@ target_link_libraries(my_program
         value_types::value_types
 )
 ```
+
+# Contributing
+
+We use GitHub actions to ensure that all changes have test coverage and that
+source code is formatted with clang-format (v17).
+
+We use CMake and Bazel. New targets are manually added to both.

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -463,7 +463,6 @@ struct POCSTrackingAllocator : TrackingAllocator<T> {
 };
 
 TEST(IndirectTest, NonMemberSwapWhenAllocatorsDontCompareEqual) {
-
   unsigned alloc_counter = 0;
   unsigned dealloc_counter = 0;
   {
@@ -651,17 +650,25 @@ TEST(IndirectTest, HashCustomAllocator) {
 #if (__cpp_lib_format >= 201907L)
 
 TEST(IndirectTest, FormatNativeTypesDefaultFormatting) {
-  EXPECT_EQ(std::format("{}", xyz::indirect<bool>(std::in_place, true)), "true");
+  EXPECT_EQ(std::format("{}", xyz::indirect<bool>(std::in_place, true)),
+            "true");
   EXPECT_EQ(std::format("{}", xyz::indirect<int>(std::in_place, 100)), "100");
-  EXPECT_EQ(std::format("{}", xyz::indirect<float>(std::in_place, 50.0f)), "50");
-  EXPECT_EQ(std::format("{}", xyz::indirect<double>(std::in_place, 25.0)), "25");
+  EXPECT_EQ(std::format("{}", xyz::indirect<float>(std::in_place, 50.0f)),
+            "50");
+  EXPECT_EQ(std::format("{}", xyz::indirect<double>(std::in_place, 25.0)),
+            "25");
 }
 
 TEST(IndirectTest, FormatNativeTypesPropagateFormatting) {
-  EXPECT_EQ(std::format("{:*<6}", xyz::indirect<bool>(std::in_place, true)), "true**");
-  EXPECT_EQ(std::format("{:*^7}", xyz::indirect<int>(std::in_place, 100)), "**100**");
-  EXPECT_EQ(std::format("{:>7}", xyz::indirect<float>(std::in_place, 50.0f)), "     50");
-  EXPECT_EQ(std::format("{:+8.3e}", xyz::indirect<double>(std::in_place, 25.75)), "+2.575e+01");
+  EXPECT_EQ(std::format("{:*<6}", xyz::indirect<bool>(std::in_place, true)),
+            "true**");
+  EXPECT_EQ(std::format("{:*^7}", xyz::indirect<int>(std::in_place, 100)),
+            "**100**");
+  EXPECT_EQ(std::format("{:>7}", xyz::indirect<float>(std::in_place, 50.0f)),
+            "     50");
+  EXPECT_EQ(
+      std::format("{:+8.3e}", xyz::indirect<double>(std::in_place, 25.75)),
+      "+2.575e+01");
 }
 
 #endif  // __cpp_lib_format >= 201907L


### PR DESCRIPTION
Use clang-format 17 to check format for source code.