### PR TITLE
Remove optional specialization as requested by LEWG

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -183,16 +183,10 @@ currently used to (mis)represent component objects. Putting `T` onto the free
 store should not make it nullable. Nullability must be explicitly opted into by
 using `std::optional<indirect<T>>` or `std::optional<polymorphic<T>>`.
 
-`std::optional<>` is specialized for `indirect<>` and `polymorphic<>` so they
-incur no additional overhead.
-
-Access to a `std::optional<indirect<T>>` or `std::optional<polymorphic<T>>` can
-be done with double indirection, `(**v)`, or with a single arrow operator to
-access a member, `v->some_member`.
-
-Note: As the null state of `indirect` and `polymorphic` is not observable, and
-access to a moved-from object is erroneous, `std::optional` can be specialized
-by implementers to exchange pointers on move construction and assignment.
+We invite implementers to optimise their implementation of `optional<indirect>`
+and `optional<polymorphic>` to exploit the non-observable nature of the
+valueless state and minimise the size of an `optional<indirect>` or
+`optional<polymorphic>`.
 
 ### Allocator support
 
@@ -884,34 +878,7 @@ type `indirect<T, Alloc>`, then `hash<indirect<T, Alloc>>()(i)` evaluates to the
 same value as `hash<remove_const_t<T>>()(*i)`. The member functions are not
 guaranteed to be noexcept.
 
-#### X.Y.12 Optional support [indirect.optional]
-
-```c++
-template <class T, class Alloc>
-class std::optional<indirect<T, Alloc>>;
-```
-
-The specialization `std::optional<indirect<T, Alloc>>` guarantees
-`sizeof(std::optional<indirect<T, Alloc>>) == sizeof(indirect<T, Alloc>>)`.
-
-```c++
-// [optional.observe], observers
-constexpr const indirect<T, Alloc>& operator->() const noexcept;
-constexpr indirect<T, Alloc>& operator->() noexcept;
-```
-
-* _Preconditions_: `*this` contains a value. The contained indirect value is not
-  valueless.
-
-* _Returns_: `val`.
-
-* _Remarks_: These functions are constexpr. The specialization
-  `std::optional<indirect<T, Alloc>>` provides `operator->` that returns a
-  reference to the contained `indirect`.
-
-Otherwise, the interface of the specialization is as defined in [optional].
-
-#### X.Y.13 Formatter support [indirect.fmt]
+#### X.Y.11 Formatter support [indirect.fmt]
 
 ```c++
 // [indirect.fmt]
@@ -1245,34 +1212,6 @@ constexpr void swap(polymorphic& lhs, polymorphic& rhs);
 ```
 
 * _Effects_: Equivalent to `lhs.swap(rhs)`.
-
-#### X.Z.8 Optional support [polymorphic.optional]
-
-```c++
-template <class T, class Alloc>
-class std::optional<polymorphic<T, Alloc>>;
-```
-
-The specialization `std::optional<polymorphic<T, Alloc>>` guarantees
-`sizeof(std::optional<polymorphic<T, Alloc>>) == sizeof(polymorphic<T,
-Alloc>>)`.
-
-```c++
-// [optional.observe], observers
-constexpr const polymorphic<T, Alloc>& operator->() const noexcept;
-constexpr polymorphic<T, Alloc>& operator->() noexcept;
-```
-
-* _Preconditions_: `*this` is not valueless. The contained polymorphic value is
-  not valueless.
-
-* _Returns_: `val`.
-
-* _Remarks_: These functions are constexpr. The specialization
-  `std::optional<polymorphic<T, Alloc>>` provides `operator->` that returns a
-  reference to the contained `polymorphic`.
-
-Otherwise, the interface of the specialization is as defined in [optional].
 
 ## Feature-test Macro [polymorphic.predefined.ft]
 


### PR DESCRIPTION
@sean-parent LEWG wanted discussion of optional specialization removing with the explicit understanding that it can be added (and probably should be added) as another paper for C++26. Time was against us and this was impeding consensus. It's simple enough to look at in isolation.