### PR TITLE
Ensure that swap with self is safe

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@ test --test_output=errors
 
 build --cxxopt='-std=c++20'
 build --cxxopt='-Wno-delete-non-abstract-non-virtual-dtor'
+build --cxxopt='-Wno-self-assign-overloaded'
 build --cxxopt='-Wno-self-move'
 
 build:asan --strip=never

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -277,8 +277,8 @@ propagates const and is allocator aware.
 
 #### Similarities and dissimilarities with variant
 
-The sum type `variant<Ts...>` models one of several alternatives;
-`indirect<T>` models a single type `T`, but with different storage constraints.
+The sum type `variant<Ts...>` models one of several alternatives; `indirect<T>`
+models a single type `T`, but with different storage constraints.
 
 Like `indirect`, a variant can get into a valueless state. For variant, this
 valueless state is accessible when an exception is thrown when changing the
@@ -375,11 +375,11 @@ either `allocator_type::value_type` or an internal type used by the indirect
 value.
 
 Copy constructors for an indirect value obtain an allocator by calling
-`allocator_traits<allocator_type>::select_on_container_copy_construction` on
-the allocator belonging to the indirect value being copied. Move constructors
-obtain an allocator by move construction from the allocator belonging to the
-container being moved. Such move construction of the allocator shall not exit
-via an exception. All other constructors for these container types take a `const
+`allocator_traits<allocator_type>::select_on_container_copy_construction` on the
+allocator belonging to the indirect value being copied. Move constructors obtain
+an allocator by move construction from the allocator belonging to the container
+being moved. Such move construction of the allocator shall not exit via an
+exception. All other constructors for these container types take a `const
 allocator_type& argument`. [Note 3:If an invocation of a constructor uses the
 default value of an optional allocator argument, then the allocator type must
 support value-initialization.  end note] A copy of this allocator is used for
@@ -391,9 +391,8 @@ move assignment, or swapping of the allocator only if (64.1)
 `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value`,
 (64.2)
 `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value`,
-or (64.3)
-`allocator_traits<allocator_type>::propagate_on_container_swap::value` is
-true within the implementation of the corresponding indirect value operation.
+or (64.3) `allocator_traits<allocator_type>::propagate_on_container_swap::value`
+is true within the implementation of the corresponding indirect value operation.
 
 The template parameter `T` of `indirect` must be a non-union class type.
 
@@ -668,7 +667,7 @@ constexpr indirect& operator=(const indirect& other);
 
 * _Preconditions_: `other` is not valueless.
 
-* _Effects_: If
+* _Effects_: If `this==&other`, then does nothing. Otherwise if
   `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
   == true`, `allocator` is set to the allocator of `other`. If allocator is not
   changed, `std::is_copy_assignable_v<T>` is true, and `*this` is not valueless,
@@ -745,7 +744,8 @@ constexpr void swap(indirect& other) noexcept(
 
 * _Preconditions_: `*this` is not valueless, `other` is not valueless.
 
-* _Effects_: Swaps the objects owned by `*this` and `other`. If
+* _Effects_: If `this==&other`, then does nothing. Otherwise swaps the objects
+  owned by `*this` and `other`. If
   `allocator_traits<allocator_type>::propagate_on_container_swap::value` is
   `true`, then allocator_type shall meet the _Cpp17Swappable_ requirements and
   the allocators of `*this` and `other` shall also be exchanged by calling
@@ -964,8 +964,8 @@ either `allocator_type::value_type` or an internal type used by the polymorphic
 value.
 
 Copy constructors for a polymorphic value obtain an allocator by calling
-`allocator_traits<allocator_type>::select_on_container_copy_construction` on
-the allocator belonging to the polymorphic value being copied. Move constructors
+`allocator_traits<allocator_type>::select_on_container_copy_construction` on the
+allocator belonging to the polymorphic value being copied. Move constructors
 obtain an allocator by move construction from the allocator belonging to the
 container being moved. Such move construction of the allocator shall not exit
 via an exception. All other constructors for these container types take a `const
@@ -980,9 +980,9 @@ move assignment, or swapping of the allocator only if (64.1)
 `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value`,
 (64.2)
 `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value`,
-or (64.3)
-`allocator_traits<allocator_type>::propagate_on_container_swap::value` is
-true within the implementation of the corresponding polymorphic value operation.
+or (64.3) `allocator_traits<allocator_type>::propagate_on_container_swap::value`
+is true within the implementation of the corresponding polymorphic value
+operation.
 
 The template parameter `T` of `polymorphic` must be a non-union class type.
 
@@ -1162,8 +1162,9 @@ constexpr polymorphic& operator=(const polymorphic& other);
 
 * _Preconditions_: `other` is not valueless.
 
-* _Effects_: If `*this` is not valueless, destroys the owned object. If
-`allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
+* _Effects_: If `this==&other`, then does nothing. Otherwise if `*this` is not
+valueless, destroys the owned object. If
+  `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
   == true`, `allocator` is set to the allocator of `other`. Copy constructs a
   new object using the object owned by `other`.
 
@@ -1233,7 +1234,8 @@ constexpr void swap(polymorphic& other) noexcept(
 
 * _Preconditions_: `*this` is not valueless, `other` is not valueless.
 
-* _Effects_: Swaps the objects owned by `*this` and `other`. If
+* _Effects_: If `this==&other`, then does nothing. Otherwise swaps the objects
+  owned by `*this` and `other`. If
   `allocator_traits<allocator_type>::propagate_on_container_swap::value` is
   `true`, then allocator_type shall meet the _Cpp17Swappable_ requirements and
   the allocators of `*this` and `other` shall also be exchanged by calling

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -716,7 +716,7 @@ _Mandates_: `is_move_constructible_v<T>` is `true`.
 
 6. _Preconditions_: `other` is not valueless.
 
-7. _Effects_: If
+7. _Effects_: If `&other == this`, then has no effects. Otherwise, if
   `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value
   == true`, `allocator_` is set to the allocator of `other`. If allocator is
   propagated or is equal to the allocator of `other`, destroys the owned object,
@@ -1154,8 +1154,9 @@ constexpr polymorphic& operator=(const polymorphic& other);
 
 1. _Preconditions_: `other` is not valueless.
 
-2. _Effects_: If `*this` is not valueless, destroys the owned object. If
-`allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
+2. _Effects_: If `&other == this`, then has no effects. Otherwise, if `*this` is not
+valueless, destroys the owned object. If
+  `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
   == true`, `allocator_` is set to the allocator of `other`. Copy constructs a
   new object using the object owned by `other`.
 
@@ -1169,7 +1170,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
 
 4. _Preconditions_: `other` is not valueless.
 
-5. _Effects_: If
+5. _Effects_: If `&other == this`, then has no effects. Otherwise, if
   `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value
   == true`, `allocator_` is set to the allocator of `other`. If allocator is
   propagated or is equal to the allocator of `other`, destroys the owned object,

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -772,15 +772,13 @@ constexpr void swap(indirect& other) noexcept(
 
 1. _Preconditions_: `*this` is not valueless, `other` is not valueless.
 
-2. _Effects_: If `this==&other`, then does nothing. Otherwise, swaps the objects
-  owned by `*this` and `other`. If
+2. _Effects_: Swaps the objects owned by `*this` and `other`. If
   `allocator_traits<allocator_type>::propagate_on_container_swap::value` is
   `true`, then `allocator_type` shall meet the _Cpp17Swappable_ requirements and
-  the allocators of `*this` and `other` are exchanged by calling `swap` as
-  described in [swappable.requirements]. Otherwise, the allocators are not
-  swapped, and the behavior is undefined unless `(*this).get_allocator() ==
-  other.get_allocator()`. _[Note: Does not call `swap` on the owned objects
-  directly. --end note]_
+  the allocators of `*this` and `other` are exchanged by calling
+  `swap` as described in [swappable.requirements]. Otherwise, the allocators
+  are not swapped, and the behavior is undefined unless
+  `(*this).get_allocator() == other.get_allocator()`. _[Note: Does not call `swap` on the owned objects directly. --end note]_
 
 ```c++
 constexpr void swap(indirect& lhs, indirect& rhs) noexcept(
@@ -1223,15 +1221,14 @@ constexpr void swap(polymorphic& other) noexcept(
 
 1. _Preconditions_: `*this` is not valueless, `other` is not valueless.
 
-2. _Effects_: If `this==&other`, then does nothing. Otherwise, swaps the objects
-  owned by `*this` and `other`. If
+2. _Effects_: Swaps the objects owned by `*this` and `other`. If
   `allocator_traits<allocator_type>::propagate_on_container_swap::value` is
   `true`, then `allocator_type` shall meet the _Cpp17Swappable_ requirements and
-  the allocators of `*this` and `other` are exchanged by calling `swap` as
-  described in [swappable.requirements]. Otherwise, the allocators are swapped,
-  and the behavior is undefined unless `(*this).get_allocator() ==
-  other.get_allocator()`. _[Note: Does not call `swap` on the owned objects
-  directly. --end note]_
+  the allocators of `*this` and `other` are exchanged by calling
+  `swap` as described in [swappable.requirements]. Otherwise, the allocators
+  are swapped, and the behavior is undefined unless
+  `(*this).get_allocator() == other.get_allocator()`.
+  _[Note: Does not call `swap` on the owned objects directly. --end note]_
 
 ```c++
 constexpr void swap(polymorphic& lhs, polymorphic& rhs) noexcept(

--- a/cmake/vt_add_test.cmake
+++ b/cmake/vt_add_test.cmake
@@ -62,7 +62,7 @@ function(vt_add_test)
                 $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
                 $<$<CXX_COMPILER_ID:MSVC>:/W4>
                 $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
-                $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-delete-non-abstract-non-virtual-dtor;-Wno-unknown-warning-option;-Wno-self-move>
+                $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-delete-non-abstract-non-virtual-dtor;-Wno-unknown-warning-option;-Wno-self-move;-Wno-self-assign-overloaded>
         )
 
     endif (NOT TARGET common_compiler_settings)

--- a/indirect.h
+++ b/indirect.h
@@ -212,8 +212,10 @@ class indirect {
     assert(p_ != nullptr);        // LCOV_EXCL_LINE
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
 
-    if (this == &other) { return; }
-    
+    if (this == &other) {
+      return;
+    }
+
     if constexpr (allocator_traits::propagate_on_container_swap::value) {
       // If allocators move with their allocated objects we can swap both.
       std::swap(alloc_, other.alloc_);

--- a/indirect.h
+++ b/indirect.h
@@ -211,13 +211,8 @@ class indirect {
       std::allocator_traits<A>::is_always_equal::value) {
     assert(p_ != nullptr);        // LCOV_EXCL_LINE
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
-
-    if (this == &other) {
-      return;
-    }
-
     if constexpr (allocator_traits::propagate_on_container_swap::value) {
-      // If allocators move with their allocated objects we can swap both.
+      // If allocators move with their allocated objects, we can swap both.
       std::swap(alloc_, other.alloc_);
       std::swap(p_, other.p_);
       return;

--- a/indirect.h
+++ b/indirect.h
@@ -209,6 +209,8 @@ class indirect {
     assert(p_ != nullptr);        // LCOV_EXCL_LINE
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
 
+    if (this == &other) { return; }
+    
     if constexpr (allocator_traits::propagate_on_container_swap::value) {
       // If allocators move with their allocated objects we can swap both.
       std::swap(alloc_, other.alloc_);

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -108,6 +108,13 @@ TEST(IndirectTest, MemberSwap) {
   EXPECT_EQ(*b, 42);
 }
 
+TEST(IndirectTest, MemberSwapWithSelf) {
+  xyz::indirect<int> a(42);
+
+  a.swap(a);
+  EXPECT_FALSE(a.valueless_after_move());
+}
+
 TEST(IndirectTest, ConstPropagation) {
   struct SomeType {
     enum class Constness { LV_CONST, LV_NON_CONST, RV_CONST, RV_NON_CONST };

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -80,6 +80,13 @@ TEST(IndirectTest, CopyAssignment) {
   EXPECT_NE(&*a, &*b);
 }
 
+TEST(IndirectTest, CopyAssignmentToSelf) {
+  xyz::indirect<int> a(42);
+  a = a;
+
+  EXPECT_FALSE(a.valueless_after_move());
+}
+
 TEST(IndirectTest, MoveAssignment) {
   xyz::indirect<int> a(42);
   xyz::indirect<int> b(101);

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -80,7 +80,7 @@ TEST(IndirectTest, CopyAssignment) {
   EXPECT_NE(&*a, &*b);
 }
 
-TEST(IndirectTest, CopyAssignmentToSelf) {
+TEST(IndirectTest, CopyAssignmentSelf) {
   xyz::indirect<int> a(42);
   a = a;
 
@@ -95,6 +95,13 @@ TEST(IndirectTest, MoveAssignment) {
 
   EXPECT_TRUE(b.valueless_after_move());
   EXPECT_EQ(*a, 101);
+}
+
+TEST(IndirectTest, MoveAssignmentSelf) {
+  xyz::indirect<int> a(42);
+  a = std::move(a);
+
+  EXPECT_FALSE(a.valueless_after_move());
 }
 
 TEST(IndirectTest, NonMemberSwap) {

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -260,14 +260,10 @@ class polymorphic {
   constexpr void swap(polymorphic& other) noexcept(
       std::allocator_traits<A>::propagate_on_container_swap::value ||
       std::allocator_traits<A>::is_always_equal::value) {
+    assert(cb_ != nullptr);        // LCOV_EXCL_LINE
     assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
-
-    if (this == &other) {
-      return;
-    }
-
     if constexpr (allocator_traits::propagate_on_container_swap::value) {
-      // If allocators move with their allocated objects we can swap both.
+      // If allocators move with their allocated objects, we can swap both.
       std::swap(alloc_, other.alloc_);
       std::swap(cb_, other.cb_);
       return;

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -272,8 +272,10 @@ class polymorphic {
       std::allocator_traits<A>::is_always_equal::value) {
     assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
 
-    if (this == &other) { return; }
-    
+    if (this == &other) {
+      return;
+    }
+
     if constexpr (allocator_traits::propagate_on_container_swap::value) {
       // If allocators move with their allocated objects we can swap both.
       std::swap(alloc_, other.alloc_);

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -269,6 +269,8 @@ class polymorphic {
       std::allocator_traits<A>::is_always_equal::value) {
     assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
 
+    if (this == &other) { return; }
+    
     if constexpr (allocator_traits::propagate_on_container_swap::value) {
       // If allocators move with their allocated objects we can swap both.
       std::swap(alloc_, other.alloc_);

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -172,6 +172,13 @@ TEST(PolymorphicTest, MemberSwap) {
   EXPECT_EQ(b->value(), 42);
 }
 
+TEST(PolymorphicTest, MemberSwapWithSelf) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+
+  a.swap(a);
+  EXPECT_FALSE(a.valueless_after_move());
+}
+
 TEST(PolymorphicTest, ConstPropagation) {
   struct SomeType {
     enum class Constness { CONST, NON_CONST };

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -144,6 +144,13 @@ TEST(PolymorphicTest, CopyAssignment) {
   EXPECT_NE(&*a, &*b);
 }
 
+TEST(IndirectTest, CopyAssignmentToSelf) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  a = a;
+
+  EXPECT_FALSE(a.valueless_after_move());
+}
+
 TEST(PolymorphicTest, MoveAssignment) {
   xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
   xyz::polymorphic<Base> b(xyz::in_place_type_t<Derived>{}, 101);

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -144,7 +144,7 @@ TEST(PolymorphicTest, CopyAssignment) {
   EXPECT_NE(&*a, &*b);
 }
 
-TEST(IndirectTest, CopyAssignmentToSelf) {
+TEST(IndirectTest, CopyAssignmentSelf) {
   xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
   a = a;
 
@@ -159,6 +159,13 @@ TEST(PolymorphicTest, MoveAssignment) {
 
   EXPECT_TRUE(b.valueless_after_move());
   EXPECT_EQ(a->value(), 101);
+}
+
+TEST(IndirectTest, MoveAssignmentSelf) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  a = std::move(a);
+
+  EXPECT_FALSE(a.valueless_after_move());
 }
 
 TEST(PolymorphicTest, NonMemberSwap) {


### PR DESCRIPTION
Tests to make sure that self-swap and self-assign should do not make an object valueless.