### PR TITLE
Define `unreachable` only once, even if including both headers

### DIFF
--- a/indirect.h
+++ b/indirect.h
@@ -34,6 +34,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 namespace xyz {
 
+#ifndef XYZ_UNREACHABLE_DEFINED
+#define XYZ_UNREACHABLE_DEFINED
 [[noreturn]] inline void unreachable() {  // LCOV_EXCL_LINE
 #if (__cpp_lib_unreachable >= 202202L)
   std::unreachable();  // LCOV_EXCL_LINE
@@ -43,6 +45,7 @@ namespace xyz {
   __builtin_unreachable();  // LCOV_EXCL_LINE
 #endif
 }
+#endif  // XYZ_UNREACHABLE_DEFINED
 
 template <class T, class A>
 class indirect;

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -36,6 +36,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 namespace xyz {
 
+#ifndef XYZ_UNREACHABLE_DEFINED
+#define XYZ_UNREACHABLE_DEFINED
 [[noreturn]] inline void unreachable() {  // LCOV_EXCL_LINE
 #if (__cpp_lib_unreachable >= 202202L)
   std::unreachable();  // LCOV_EXCL_LINE
@@ -45,6 +47,7 @@ namespace xyz {
   __builtin_unreachable();  // LCOV_EXCL_LINE
 #endif
 }
+#endif  // XYZ_UNREACHABLE_DEFINED
 
 struct NoPolymorphicSBO {};
 


### PR DESCRIPTION
Right now, including both indirect.h and polymorphic.h will lead to a compiler error: `error: redefinition of 'unreachable'`. Because both headers define the function `unreachable`. By wrapping it in a macro, we ensure that it will only be defined once.