### PR TITLE
Add death test for non-propagating swap when allocators are not equal

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -120,4 +120,4 @@ jobs:
         working-directory: ${{github.workspace}}/build
         # Execute tests defined by the CMake configuration.
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest -C ${{ matrix.configuration }}
+        run: ctest -C ${{ matrix.configuration }} --output-on-failure

--- a/cmake/vt_add_test.cmake
+++ b/cmake/vt_add_test.cmake
@@ -37,7 +37,7 @@ function(vt_add_test)
                 $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
                 $<$<CXX_COMPILER_ID:MSVC>:/W4>
                 $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
-                $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option>
+                $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option;-Wno-self-move>
         )
 
     endif (NOT TARGET common_compiler_settings)

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -797,6 +797,7 @@ struct NonEqualAllocator : std::allocator<T> {
 
 // `unreachable` only causes termination in debug mode.
 #ifndef NDEBUG
+#if defined(__has_feature) && !__has_feature(thread_sanitizer)
 TEST(IndirectTest, AllocatorSwapUnreachable) {
   NonEqualAllocator<int> allocA;
   NonEqualAllocator<int> allocB;
@@ -807,6 +808,7 @@ TEST(IndirectTest, AllocatorSwapUnreachable) {
 
   EXPECT_DEATH([&]() { iA.swap(iB); }(), "");
 }
+#endif  // defined(__has_feature) && !__has_feature(thread_sanitizer)
 #endif  // NDEBUG
 
 }  // namespace

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -783,4 +783,27 @@ TEST(IndirectTest, TaggedAllocatorEqualAllocatorMoveAssign) {
 
   red = std::move(red);  // -Wno-self-move
 }
+
+template <typename T>
+struct NonEqualAllocator : std::allocator<T> {
+  using propagate_on_container_swap = std::false_type;
+  using propagate_on_container_copy_assignment = std::false_type;
+  using propagate_on_container_move_assignment = std::false_type;
+
+  friend bool operator==(const NonEqualAllocator&, const NonEqualAllocator) {
+    return false;
+  }
+};
+
+TEST(IndirectTest, AllocatorSwapUnreachable) {
+  NonEqualAllocator<int> allocA;
+  NonEqualAllocator<int> allocB;
+
+  xyz::indirect<int, NonEqualAllocator<int>> iA(std::allocator_arg, allocA, 10);
+  xyz::indirect<int, NonEqualAllocator<int>> iB(std::allocator_arg, allocB,
+                                                220);
+
+  EXPECT_DEATH([&]() { iA.swap(iB); }(), "");
+}
+
 }  // namespace

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -797,7 +797,7 @@ struct NonEqualAllocator : std::allocator<T> {
 
 // `unreachable` only causes termination in debug mode.
 #ifndef NDEBUG
-#if defined(__has_feature) && !__has_feature(thread_sanitizer)
+#if defined(__has_feature) && !(__has_feature(thread_sanitizer))
 TEST(IndirectTest, AllocatorSwapUnreachable) {
   NonEqualAllocator<int> allocA;
   NonEqualAllocator<int> allocB;

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -795,6 +795,8 @@ struct NonEqualAllocator : std::allocator<T> {
   }
 };
 
+// `unreachable` only causes termination in debug mode.
+#ifndef NDEBUG
 TEST(IndirectTest, AllocatorSwapUnreachable) {
   NonEqualAllocator<int> allocA;
   NonEqualAllocator<int> allocB;
@@ -805,5 +807,6 @@ TEST(IndirectTest, AllocatorSwapUnreachable) {
 
   EXPECT_DEATH([&]() { iA.swap(iB); }(), "");
 }
+#endif // NDEBUG
 
 }  // namespace

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -807,6 +807,6 @@ TEST(IndirectTest, AllocatorSwapUnreachable) {
 
   EXPECT_DEATH([&]() { iA.swap(iB); }(), "");
 }
-#endif // NDEBUG
+#endif  // NDEBUG
 
 }  // namespace

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -825,6 +825,8 @@ struct NonEqualAllocator : std::allocator<T> {
   }
 };
 
+// `unreachable` only causes termination in debug mode.
+#ifndef NDEBUG
 TEST(PolymorphicTest, AllocatorSwapUnreachable) {
   NonEqualAllocator<Base> allocA;
   NonEqualAllocator<Base> allocB;
@@ -836,5 +838,6 @@ TEST(PolymorphicTest, AllocatorSwapUnreachable) {
 
   EXPECT_DEATH([&]() { pA.swap(pB); }(), "");
 }
+#ifndef // NDEBUG
 
 }  // namespace

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -838,6 +838,6 @@ TEST(PolymorphicTest, AllocatorSwapUnreachable) {
 
   EXPECT_DEATH([&]() { pA.swap(pB); }(), "");
 }
-#ifndef // NDEBUG
+#endif // NDEBUG
 
 }  // namespace

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -827,6 +827,7 @@ struct NonEqualAllocator : std::allocator<T> {
 
 // `unreachable` only causes termination in debug mode.
 #ifndef NDEBUG
+#if defined(__has_feature) && !__has_feature(thread_sanitizer)
 TEST(PolymorphicTest, AllocatorSwapUnreachable) {
   NonEqualAllocator<Base> allocA;
   NonEqualAllocator<Base> allocB;
@@ -838,6 +839,7 @@ TEST(PolymorphicTest, AllocatorSwapUnreachable) {
 
   EXPECT_DEATH([&]() { pA.swap(pB); }(), "");
 }
+#endif  // defined(__has_feature) && !__has_feature(thread_sanitizer)
 #endif  // NDEBUG
 
 }  // namespace

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -838,6 +838,6 @@ TEST(PolymorphicTest, AllocatorSwapUnreachable) {
 
   EXPECT_DEATH([&]() { pA.swap(pB); }(), "");
 }
-#endif // NDEBUG
+#endif  // NDEBUG
 
 }  // namespace

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -827,7 +827,7 @@ struct NonEqualAllocator : std::allocator<T> {
 
 // `unreachable` only causes termination in debug mode.
 #ifndef NDEBUG
-#if defined(__has_feature) && !__has_feature(thread_sanitizer)
+#if defined(__has_feature) && !(__has_feature(thread_sanitizer))
 TEST(PolymorphicTest, AllocatorSwapUnreachable) {
   NonEqualAllocator<Base> allocA;
   NonEqualAllocator<Base> allocB;


### PR DESCRIPTION
Adds a test for UB in swap with on-equal allocators

Fixes #202 