### PR TITLE
Add unprofiled hidden-inline macro for indirect and polymorphic

### DIFF
--- a/indirect.h
+++ b/indirect.h
@@ -34,9 +34,18 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 namespace xyz {
 
+#ifndef XYZ_HIDDEN_INLINED
+#if defined(_MSC_VER)
+#define XYZ_HIDDEN_INLINED
+#else
+#define XYZ_HIDDEN_INLINED \
+  __attribute__((__visibility__("hidden"))) __attribute__((__always_inline__))
+#endif  // defined(_MSC_VER)
+#endif  // XYZ_HIDDEN_INLINED
+
 #ifndef XYZ_UNREACHABLE_DEFINED
 #define XYZ_UNREACHABLE_DEFINED
-[[noreturn]] inline void unreachable() {  // LCOV_EXCL_LINE
+[[noreturn]] XYZ_HIDDEN_INLINED inline void unreachable() {  // LCOV_EXCL_LINE
 #if (__cpp_lib_unreachable >= 202202L)
   std::unreachable();  // LCOV_EXCL_LINE
 #elif defined(_MSC_VER)
@@ -66,20 +75,21 @@ class indirect {
   using pointer = typename allocator_traits::pointer;
   using const_pointer = typename allocator_traits::const_pointer;
 
-  constexpr indirect()
+  XYZ_HIDDEN_INLINED constexpr indirect()
     requires std::is_default_constructible_v<A>
   {
     static_assert(std::is_default_constructible_v<T>);
     p_ = construct_from(alloc_);
   }
 
-  constexpr indirect(std::allocator_arg_t, const A& alloc) : alloc_(alloc) {
+  XYZ_HIDDEN_INLINED constexpr indirect(std::allocator_arg_t, const A& alloc)
+      : alloc_(alloc) {
     static_assert(std::is_default_constructible_v<T>);
     p_ = construct_from(alloc_);
   }
 
   template <class U, class... Us>
-  explicit constexpr indirect(U&& u, Us&&... us)
+  XYZ_HIDDEN_INLINED explicit constexpr indirect(U&& u, Us&&... us)
     requires(std::constructible_from<T, U &&, Us && ...> &&
              std::is_default_constructible_v<A> &&
              !std::is_same_v<std::remove_cvref_t<U>, indirect>)
@@ -88,14 +98,15 @@ class indirect {
   }
 
   template <class U, class... Us>
-  constexpr indirect(std::allocator_arg_t, const A& alloc, U&& u, Us&&... us)
+  XYZ_HIDDEN_INLINED constexpr indirect(std::allocator_arg_t, const A& alloc,
+                                        U&& u, Us&&... us)
     requires(std::constructible_from<T, U &&, Us && ...> &&
              !std::is_same_v<std::remove_cvref_t<U>, indirect>)
       : alloc_(alloc) {
     p_ = construct_from(alloc_, std::forward<U>(u), std::forward<Us>(us)...);
   }
 
-  constexpr indirect(const indirect& other)
+  XYZ_HIDDEN_INLINED constexpr indirect(const indirect& other)
       : alloc_(allocator_traits::select_on_container_copy_construction(
             other.alloc_)) {
     static_assert(std::is_copy_constructible_v<T>);
@@ -103,30 +114,30 @@ class indirect {
     p_ = construct_from(alloc_, *other);
   }
 
-  constexpr indirect(std::allocator_arg_t, const A& alloc,
-                     const indirect& other)
+  XYZ_HIDDEN_INLINED constexpr indirect(std::allocator_arg_t, const A& alloc,
+                                        const indirect& other)
       : alloc_(alloc) {
     static_assert(std::is_copy_constructible_v<T>);
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     p_ = construct_from(alloc_, *other);
   }
 
-  constexpr indirect(indirect&& other) noexcept
+  XYZ_HIDDEN_INLINED constexpr indirect(indirect&& other) noexcept
       : p_(nullptr), alloc_(other.alloc_) {
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     std::swap(p_, other.p_);
   }
 
-  constexpr indirect(std::allocator_arg_t, const A& alloc,
-                     indirect&& other) noexcept
+  XYZ_HIDDEN_INLINED constexpr indirect(std::allocator_arg_t, const A& alloc,
+                                        indirect&& other) noexcept
       : p_(nullptr), alloc_(alloc) {
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     std::swap(p_, other.p_);
   }
 
-  constexpr ~indirect() { reset(); }
+  XYZ_HIDDEN_INLINED constexpr ~indirect() { reset(); }
 
-  constexpr indirect& operator=(const indirect& other) {
+  XYZ_HIDDEN_INLINED constexpr indirect& operator=(const indirect& other) {
     if (this == &other) return *this;
     assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     static_assert(std::is_copy_constructible_v<T>);
@@ -149,7 +160,7 @@ class indirect {
     return *this;
   }
 
-  constexpr indirect& operator=(indirect&& other) noexcept(
+  XYZ_HIDDEN_INLINED constexpr indirect& operator=(indirect&& other) noexcept(
       allocator_traits::propagate_on_container_move_assignment::value ||
       allocator_traits::is_always_equal::value) {
     if (this == &other) return *this;
@@ -172,41 +183,45 @@ class indirect {
     return *this;
   }
 
-  constexpr const T& operator*() const& noexcept {
+  XYZ_HIDDEN_INLINED constexpr const T& operator*() const& noexcept {
     assert(p_ != nullptr);  // LCOV_EXCL_LINE
     return *p_;
   }
 
-  constexpr T& operator*() & noexcept {
+  XYZ_HIDDEN_INLINED constexpr T& operator*() & noexcept {
     assert(p_ != nullptr);  // LCOV_EXCL_LINE
     return *p_;
   }
 
-  constexpr T&& operator*() && noexcept {
+  XYZ_HIDDEN_INLINED constexpr T&& operator*() && noexcept {
     assert(p_ != nullptr);  // LCOV_EXCL_LINE
     return std::move(*p_);
   }
 
-  constexpr const T&& operator*() const&& noexcept {
+  XYZ_HIDDEN_INLINED constexpr const T&& operator*() const&& noexcept {
     assert(p_ != nullptr);  // LCOV_EXCL_LINE
     return std::move(*p_);
   }
 
-  constexpr const_pointer operator->() const noexcept {
+  XYZ_HIDDEN_INLINED constexpr const_pointer operator->() const noexcept {
     assert(p_ != nullptr);  // LCOV_EXCL_LINE
     return p_;
   }
 
-  constexpr pointer operator->() noexcept {
+  XYZ_HIDDEN_INLINED constexpr pointer operator->() noexcept {
     assert(p_ != nullptr);  // LCOV_EXCL_LINE
     return p_;
   }
 
-  constexpr bool valueless_after_move() const noexcept { return p_ == nullptr; }
+  XYZ_HIDDEN_INLINED constexpr bool valueless_after_move() const noexcept {
+    return p_ == nullptr;
+  }
 
-  constexpr allocator_type get_allocator() const noexcept { return alloc_; }
+  XYZ_HIDDEN_INLINED constexpr allocator_type get_allocator() const noexcept {
+    return alloc_;
+  }
 
-  constexpr void swap(indirect& other) noexcept(
+  XYZ_HIDDEN_INLINED constexpr void swap(indirect& other) noexcept(
       std::allocator_traits<A>::propagate_on_container_swap::value ||
       std::allocator_traits<A>::is_always_equal::value) {
     assert(p_ != nullptr);        // LCOV_EXCL_LINE
@@ -226,14 +241,14 @@ class indirect {
     }
   }
 
-  friend constexpr void swap(indirect& lhs,
-                             indirect& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+  XYZ_HIDDEN_INLINED friend constexpr void swap(
+      indirect& lhs, indirect& rhs) noexcept(noexcept(lhs.swap(rhs))) {
     lhs.swap(rhs);
   }
 
   template <class U, class AA>
-  friend constexpr bool operator==(const indirect<T, A>& lhs,
-                                   const indirect<U, AA>& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr bool operator==(
+      const indirect<T, A>& lhs, const indirect<U, AA>& rhs)
     requires std::equality_comparable_with<T, U>
   {
     assert(!lhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -242,8 +257,8 @@ class indirect {
   }
 
   template <class U, class AA>
-  friend constexpr bool operator!=(const indirect<T, A>& lhs,
-                                   const indirect<U, AA>& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr bool operator!=(
+      const indirect<T, A>& lhs, const indirect<U, AA>& rhs)
     requires std::equality_comparable_with<T, U>
   {
     assert(!lhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -252,8 +267,8 @@ class indirect {
   }
 
   template <class U, class AA>
-  friend constexpr auto operator<=>(const indirect<T, A>& lhs,
-                                    const indirect<U, AA>& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr auto operator<=>(
+      const indirect<T, A>& lhs, const indirect<U, AA>& rhs)
     requires std::three_way_comparable_with<T, U>
   {
     assert(!lhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -262,7 +277,8 @@ class indirect {
   }
 
   template <class U>
-  friend constexpr bool operator==(const indirect<T, A>& lhs, const U& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr bool operator==(const indirect<T, A>& lhs,
+                                                      const U& rhs)
     requires(!is_indirect_v<U>)
   {
     assert(!lhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -270,7 +286,8 @@ class indirect {
   }
 
   template <class U>
-  friend constexpr bool operator==(const U& lhs, const indirect<T, A>& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr bool operator==(const U& lhs,
+                                                      const indirect<T, A>& rhs)
     requires(!is_indirect_v<U>)
   {
     assert(!rhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -278,7 +295,8 @@ class indirect {
   }
 
   template <class U>
-  friend constexpr bool operator!=(const indirect<T, A>& lhs, const U& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr bool operator!=(const indirect<T, A>& lhs,
+                                                      const U& rhs)
     requires(!is_indirect_v<U>)
   {
     assert(!lhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -286,7 +304,8 @@ class indirect {
   }
 
   template <class U>
-  friend constexpr bool operator!=(const U& lhs, const indirect<T, A>& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr bool operator!=(const U& lhs,
+                                                      const indirect<T, A>& rhs)
     requires(!is_indirect_v<U>)
   {
     assert(!rhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -294,7 +313,8 @@ class indirect {
   }
 
   template <class U>
-  friend constexpr auto operator<=>(const indirect<T, A>& lhs, const U& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr auto operator<=>(
+      const indirect<T, A>& lhs, const U& rhs)
     requires(!is_indirect_v<U>)
   {
     assert(!lhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -302,7 +322,8 @@ class indirect {
   }
 
   template <class U>
-  friend constexpr auto operator<=>(const U& lhs, const indirect<T, A>& rhs)
+  XYZ_HIDDEN_INLINED friend constexpr auto operator<=>(
+      const U& lhs, const indirect<T, A>& rhs)
     requires(!is_indirect_v<U>)
   {
     assert(!rhs.valueless_after_move());  // LCOV_EXCL_LINE
@@ -318,14 +339,14 @@ class indirect {
   [[no_unique_address]] A alloc_;
 #endif
 
-  constexpr void reset() noexcept {
+  XYZ_HIDDEN_INLINED constexpr void reset() noexcept {
     if (p_ == nullptr) return;
     destroy_with(alloc_, p_);
     p_ = nullptr;
   }
 
   template <typename... Ts>
-  constexpr static T* construct_from(A alloc, Ts&&... ts) {
+  XYZ_HIDDEN_INLINED constexpr static T* construct_from(A alloc, Ts&&... ts) {
     T* mem = allocator_traits::allocate(alloc, 1);
     try {
       allocator_traits::construct(alloc, mem, std::forward<Ts>(ts)...);
@@ -336,7 +357,7 @@ class indirect {
     }
   }
 
-  constexpr static void destroy_with(A alloc, T* p) {
+  XYZ_HIDDEN_INLINED constexpr static void destroy_with(A alloc, T* p) {
     allocator_traits::destroy(alloc, p);
     allocator_traits::deallocate(alloc, p, 1);
   }
@@ -350,7 +371,8 @@ concept is_hashable = requires(T t) { std::hash<T>{}(t); };
 template <class T, class Alloc>
   requires xyz::is_hashable<T>
 struct std::hash<xyz::indirect<T, Alloc>> {
-  constexpr std::size_t operator()(const xyz::indirect<T, Alloc>& key) const {
+  XYZ_HIDDEN_INLINED constexpr std::size_t operator()(
+      const xyz::indirect<T, Alloc>& key) const {
     return std::hash<typename xyz::indirect<T, Alloc>::value_type>{}(*key);
   }
 };
@@ -369,12 +391,14 @@ template <class T, class Alloc, class charT>
 struct std::formatter<xyz::indirect<T, Alloc>, charT>
     : std::formatter<T, charT> {
   template <class ParseContext>
-  constexpr auto parse(ParseContext& ctx) -> typename ParseContext::iterator {
+  XYZ_HIDDEN_INLINED constexpr auto parse(ParseContext& ctx) ->
+      typename ParseContext::iterator {
     return std::formatter<T, charT>::parse(ctx);
   }
 
   template <class FormatContext>
-  auto format(xyz::indirect<T, Alloc> const& value, FormatContext& ctx) const ->
+  XYZ_HIDDEN_INLINED auto format(xyz::indirect<T, Alloc> const& value,
+                                 FormatContext& ctx) const ->
       typename FormatContext::iterator {
     return std::formatter<T, charT>::format(*value, ctx);
   }


### PR DESCRIPTION
We need proof that this works before we consider merging it.