### PR TITLE
Simplify some constructors by delegating to other constructors

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -600,12 +600,10 @@ constexpr indirect(const indirect& other);
 
 * _Preconditions_: `other` is not valueless.
 
-* _Effects_: Constructs an indirect owning an instance of `T` created with the
-  copy constructor of the object owned by `other`. `allocator` is obtained by
-  calling
-  `allocator_traits<allocator_type>::select_on_container_copy_construction `on
-  the allocator belonging to the object being copied.
-
+* _Effects_: If `allocator_traits<allocator_type>::select_on_container_copy_construction` is `true`,
+  then equivalent to `indirect(allocator_arg, other.get_allocator(), *other)`,
+  otherwise equivalent to `indirect(*other)`.
+`
 * _Postconditions_: `*this` is not valueless.
 
 ```c++
@@ -618,8 +616,7 @@ constexpr indirect(std::allocator_arg_t, const Allocator& alloc,
 * _Preconditions_: `other` is not valueless and `Allocator` meets the
   _Cpp17Allocator_ requirements.
 
-* _Effects_: Equivalent to the preceding constructor except that the allocator
-  is initialized with alloc.
+* _Effects_: Equivalent to `indirect(allocator_arg, alloc, *other)`.
 
 * _Postconditions_: `*this` is not valueless.
 
@@ -629,9 +626,8 @@ constexpr indirect(indirect&& other) noexcept;
 
 * _Preconditions_: `other` is not valueless.
 
-* _Effects_: Constructs an `indirect` owning the object owned by `other`.
-  `allocator` is created by move construction from the allocator belonging to
-  the object being moved.
+* _Effects_: Constructs an `indirect` that takes ownership of the `other`'s owned object.
+  `allocator_` is initialized by move construction from `other.allocator_`.
 
 * _Postconditions_: `other` is valueless.
 
@@ -640,14 +636,14 @@ constexpr indirect(indirect&& other) noexcept;
 
 ```c++
 constexpr indirect(std::allocator_arg_t, const Allocator& alloc,
-                   indirect&& other) noexcept;
+                   indirect&& other) noexcept(allocator_traits<Allocator>::is_always_equal);
 ```
 
 * _Preconditions_: `other` is not valueless and `Allocator` meets the
   _Cpp17Allocator_ requirements.
 
-* _Effects_: Equivalent to the preceding constructors except that the allocator
-  is initialized with alloc.
+* _Effects_: If `alloc == other.get_allocator()` is `true` then equivalent to `indirect(std::move(other))`,
+  otherwise, equivalent to `indirect(allocator_arg, alloc, *std::move(other))`.
 
 * _Postconditions_: `other` is valueless.
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -600,9 +600,7 @@ constexpr indirect(const indirect& other);
 
 * _Preconditions_: `other` is not valueless.
 
-* _Effects_: If `allocator_traits<allocator_type>::select_on_container_copy_construction` is `true`,
-  then equivalent to `indirect(allocator_arg, other.get_allocator(), *other)`,
-  otherwise equivalent to `indirect(*other)`.
+* _Effects_: Equivalent to `indirect(allocator_arg, allocator_traits<allocator_type>::select_on_container_copy_construction(other.get_allocator()), *other)`.
 `
 * _Postconditions_: `*this` is not valueless.
 


### PR DESCRIPTION
For the copy/alloc+copy/alloc+move constructors specify the effects in terms of other constructors as a way of simplifying the specification.

NOTE: That this PR also makes the `indirect(std::allocator_arg_t, const Allocator& alloc, indirect&& other)` now conditionally `noexcept`. This is required because the case where `alloc != other.get_allocator()` may require allocating a new object and move-constructing the new object from `*other`.

The main question here is whether the post-condition that `other` is valueless is required to hold.
If it allocates a new object rather than taking ownership of `other`'s object, do we want to force `other` to become valueless, or just leave it having a value that is in a moved-from state?