### PR TITLE
Tweak wording for `indirect` comparison operators

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -803,7 +803,7 @@ template <class U, class AA>
 constexpr auto operator<=>(const indirect<T, A>& lhs, const indirect<U, AA>& rhs);
 ```
 
-* _Constraints_: `T op U` is well-defined.
+* _Constraints_: `*lhs` _op_ `*rhs` is well-formed.
 
 * _Preconditions_: `lhs` is not valueless, `rhs` is not valueless.
 
@@ -849,7 +849,7 @@ template <class U>
 constexpr auto operator<=>(const indirect<T, A>& lhs, const U& rhs);
 ```
 
-* _Constraints_: `T op U` is well-defined.
+* _Constraints_: `*lhs` _op_ `rhs` is well-formed.
 
 * _Preconditions_: `lhs` is not valueless.
 
@@ -893,7 +893,7 @@ template <class U>
 constexpr auto operator<=>(const U& lhs, const indirect<T, A>& rhs);
 ```
 
-* _Constraints_: `U op T` is well-defined.
+* _Constraints_: `lhs` _op_ `*rhs` is well-formed.
 
 * _Preconditions_: `rhs` is not valueless.
 


### PR DESCRIPTION
The Constraints section of the wording was trying to say that two types were comparable, rather than two const-ref lvalues to objects of those types being comparable.