### PR TITLE
Revise wording of `indirect` copy-assignment operator

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -675,7 +675,7 @@ constexpr indirect& operator=(const indirect& other);
   - `(allocator_traits<allocator_type>::destruct(alloc_, p_), allocator_traits<allocator_type>::construct(alloc_, p_, *other))`
 
 * _Postconditions_: `*this` is not valueless.
-  
+
 * _Returns_: A reference to `*this`.
 
 ```c++

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -441,6 +441,7 @@ class indirect {
 
   constexpr ~indirect();
 
+  template<class U = T>
   constexpr indirect& operator=(const indirect& other);
 
   constexpr indirect& operator=(indirect&& other) noexcept(see below);
@@ -654,28 +655,35 @@ constexpr ~indirect();
 #### X.Y.5 Assignment [indirect.assign]
 
 ```c++
+template<class U = T>
 constexpr indirect& operator=(const indirect& other);
 ```
 
-* _Mandates_: `is_copy_assignable_v<T>` and `is_copy_constructible_v<T>`is `true`.
+* _Constraints_: `is_copy_constructible_v<U>` is `true`.
 
 * _Preconditions_: `other` is not valueless.
 
-* _Effects_: If
-  `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
-  == true`, `allocator` is set to the allocator of `other`. If allocator is not
-  changed, `std::is_copy_assignable_v<T>` is true, and `*this` is not valueless,
-  copy assigns the owned object in `*this` from the owned object in `other`.
-  Otherwise, destroys the owned object, if any, then copy constructs a new
-  object using the object owned by `other`.
+* _Effects_: If `this == &other` is `true`, then has no effects.
+  Otherwise, if either:
+  - `is_copy_assignable_v<T>` is `false` and `is_nothrow_copy_constructible_v<T>` is `false`, or
+  - `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value` is `true` and
+    `allocator_ == other.allocator_` is `false`, or
+  - `*this` is valueless
+  then, equivalent to `*this = indirect(std::allocator_arg, allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value ? other.allocator_ : allocator_, *other)`
+  Otherwise, if `std::is_copy_assignable_v<T>` is `true`, then equivalent to `**this = *other`,
+  Otherwise, equivalent to:
+  - `(allocator_traits<allocator_type>::destruct(alloc_, p_), allocator_traits<allocator_type>::construct(alloc_, p_, *other))`
 
 * _Postconditions_: `*this` is not valueless.
+  
+* _Returns_: A reference to `*this`.
 
 ```c++
 constexpr indirect& operator=(indirect&& other) noexcept(
     allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
     allocator_traits<Allocator>::is_always_equal::value);
 ```
+
 _Mandates_: `is_move_constructible_v<T>` is `true`.
 
 * _Preconditions_: `other` is not valueless.
@@ -689,6 +697,8 @@ _Mandates_: `is_move_constructible_v<T>` is `true`.
   object owned by `other`.
 
 * _Postconditions_: `*this` is not valueless. `other` is valueless.
+
+* _Returns_: A reference to `*this`.
 
 #### X.Y.6 Observers [indirect.observers]
 


### PR DESCRIPTION
This should now provide the strong-exception guarantee in case that the allocation or copy-construction fails (partially addressing #230). Now defines effects in terms of move-assignment of a newly constructed object.

Updated to make it constrain on copy-constructibility of T instead of mandating (partially addressing #199).

Updated to handle self-assignment by stating this has no effects (addressing #232).

Add missing _Returns_ clause.

NOTE: The move-assignment operator wording still needs massaging in a similar way, however.