### PR TITLE
Use <memory_resource> only for C++17 and ensure std::exception base is public

### DIFF
--- a/feature_check.h
+++ b/feature_check.h
@@ -63,12 +63,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #ifdef __has_include
-#if __has_include(<memory_resource>)
+#if (__cplusplus >= 201703L) && __has_include(<memory_resource>)
 #include <memory_resource>
 #if __cpp_lib_memory_resource >= 201603L
 #define XYZ_HAS_STD_MEMORY_RESOURCE
 #endif  // __cpp_lib_memory_resource >= 201603L
-#endif  //__has_include(<memory_resource>)
+#endif  //(__cplusplus >= 201703L) && __has_include(<memory_resource>)
 #endif  //__has_include
 
 #endif  // XYZ_FEATURE_CHECK_H

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -836,10 +836,5 @@ TEST(IndirectTest, TaggedAllocatorEqualAllocatorMoveAssign) {
 
   red = std::move(red);  // -Wno-self-move
 }
-/*
-TEST(IndirectTest, TaggedAllocatorEqualAllocatorMoveAssign) {
-  std::vector<xyz::indirect<int>> values(0, 10);
 
-}
-*/
 }  // namespace

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -683,7 +683,7 @@ class TaggingAllocator {
   using propagate_on_container_copy_assignment = std::true_type;
   using propagate_on_container_move_assignment = std::true_type;
 
-  class TagMismatch : std::exception {
+  class TagMismatch : public std::exception {
     std::string message_;
 
    public:
@@ -836,4 +836,10 @@ TEST(IndirectTest, TaggedAllocatorEqualAllocatorMoveAssign) {
 
   red = std::move(red);  // -Wno-self-move
 }
+/*
+TEST(IndirectTest, TaggedAllocatorEqualAllocatorMoveAssign) {
+  std::vector<xyz::indirect<int>> values(0, 10);
+
+}
+*/
 }  // namespace


### PR DESCRIPTION
This PR fixed numerous warning in the output when compiling under Visual Studio