### PR TITLE
Allow copy, move and assign from the valueless state

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -306,7 +306,8 @@ The class template `indirect` owns an object of known type, permits copies,
 propagates const and is allocator aware.
 
 * Like `optional` and `unique_ptr`, `indirect` can be in a valueless state;
-  `indirect` can only get into the valueless state after move.
+  `indirect` can only get into the valueless state after being moved from, or
+  assignment or construction from a valueless state.
 
 * `unique_ptr` and `optional` have preconditions for `operator->` and
   `operator*`: the behavior is undefined if `*this` does not contain a value.
@@ -344,7 +345,8 @@ The class template `polymorphic` owns an object of known type, requires copies,
 propagates const and is allocator aware.
 
 * Like `optional` and `unique_ptr`, `polymorphic` can be in a valueless state;
-  `polymorphic` can only get into the valueless state after move.
+  `polymorphic` can only get into the valueless state after being moved from, or
+  assignment or construction from a valueless state.
 
 * `unique_ptr` and `optional` have preconditions for `operator->` and
   `operator*`: the behavior is undefined if `*this` does not contain a value.
@@ -801,6 +803,8 @@ constexpr indirect(allocator_arg_t, const Allocator& alloc, indirect&& other)
 20. _Effects_: If `alloc == other.get_allocator()` is `true` then equivalent to `indirect(std::move(other))`,
   otherwise, equivalent to `indirect(allocator_arg, alloc, *std::move(other))`.
 
+21. _Postconditions_: `other` is valueless.
+
 _[Note: This constructor does not require that `is_move_constructible_v<T>` is `true` --end note]_
 
 #### X.Y.4 Destructor [indirect.dtor]
@@ -909,7 +913,8 @@ constexpr void swap(indirect& other) noexcept(
   the allocators of `*this` and `other` are exchanged by calling
   `swap` as described in [swappable.requirements]. Otherwise, the allocators
   are not swapped, and the behavior is undefined unless
-  `(*this).get_allocator() == other.get_allocator()`. _[Note: Does not call `swap` on the owned objects directly. --end note]_
+  `(*this).get_allocator() == other.get_allocator()`.
+  _[Note: Does not call `swap` on the owned objects directly. --end note]_
 
 ```c++
 constexpr void swap(indirect& lhs, indirect& rhs) noexcept(
@@ -1304,7 +1309,9 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
 ```
 
 16. _Effects_: Constructs a polymorphic that takes ownership of the object owned
-  by `other`. `allocator_` is direct-non-list-initialized with `alloc`.
+  by `other` if any. `allocator_` is direct-non-list-initialized with `alloc`.
+
+17. _Postconditions_: `other` is valueless.
 
 _[Note: This constructor does not require that `is_move_constructible_v<T>`
   is `true`. --end note]_
@@ -1455,6 +1462,10 @@ the discriminant must be stored.
 
 For the sake of minimal size and efficiency, we opted to use two class
 templates.
+
+### A null state or a valueless state
+
+TODO: discuss the tradeoffs between an observable null state and a valueless state.
 
 ### Copiers, deleters, pointer constructors, and allocator support
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -746,30 +746,30 @@ constexpr indirect(const indirect& other);
 
 14. _Mandates_: `is_copy_constructible_v<T>` is `true`.
 
-16. _Effects_: Equivalent to
+15. _Effects_: Equivalent to
   `indirect(allocator_arg, allocator_traits<allocator_type>::select_on_container_copy_construction(other.get_allocator()), *other)`.
 `
-17. _Postconditions_: `*this` is not valueless.
+16. _Postconditions_: `*this` is not valueless.
 
 ```c++
 constexpr indirect(allocator_arg_t, const Allocator& alloc,
                    const indirect& other);
 ```
 
-18. _Mandates_: `is_copy_constructible_v<T>` is `true`.
+17. _Mandates_: `is_copy_constructible_v<T>` is `true`.
 
-20. _Effects_: Equivalent to `indirect(allocator_arg, alloc, *other)`.
+18. _Effects_: Equivalent to `indirect(allocator_arg, alloc, *other)`.
 
-21. _Postconditions_: `*this` is not valueless.
+19. _Postconditions_: `*this` is not valueless.
 
 ```c++
 constexpr indirect(indirect&& other) noexcept;
 ```
 
-23. _Effects_: Constructs an `indirect` that takes ownership of the `other`'s owned object and stores the address in `p_`.
+20. _Effects_: Constructs an `indirect` that takes ownership of the `other`'s owned object and stores the address in `p_`.
   `allocator_` is initialized by construction from `other.allocator_`.
 
-24. _Postconditions_: `other` is valueless.
+21. _Postconditions_: `other` is valueless.
 
 _[Note: This constructor does not require that `is_move_constructible_v<T>`
   is `true` --end note]_
@@ -779,10 +779,10 @@ constexpr indirect(allocator_arg_t, const Allocator& alloc, indirect&& other)
   noexcept(allocator_traits<Allocator>::is_always_equal);
 ```
 
-26. _Effects_: If `alloc == other.get_allocator()` is `true` then equivalent to `indirect(std::move(other))`,
+22. _Effects_: If `alloc == other.get_allocator()` is `true` then equivalent to `indirect(std::move(other))`,
   otherwise, equivalent to `indirect(allocator_arg, alloc, *std::move(other))`.
 
-27. _Postconditions_: `other` is valueless.
+23. _Postconditions_: `other` is valueless.
 
 _[Note: This constructor does not require that `is_move_constructible_v<T>` is `true` --end note]_
 
@@ -804,7 +804,7 @@ constexpr indirect& operator=(const indirect& other);
 
 1. _Mandates_: `is_copy_constructible_v<T>` is `true`.
 
-3. _Effects_: If `this == &other` is `true`, then has no effects.
+2. _Effects_: If `this == &other` is `true`, then has no effects.
   Otherwise, if either:
   - `is_copy_assignable_v<T>` is `false` and `is_nothrow_copy_constructible_v<T>` is `false`, or
   - `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value` is `true` and
@@ -815,9 +815,9 @@ constexpr indirect& operator=(const indirect& other);
   Otherwise, equivalent to:
   - `(allocator_traits<allocator_type>::destruct(alloc_, p_), allocator_traits<allocator_type>::construct(alloc_, p_, *other))`
 
-4. _Postconditions_: `*this` is not valueless.
+3. _Postconditions_: `*this` is not valueless.
 
-5. _Returns_: A reference to `*this`.
+4. _Returns_: A reference to `*this`.
 
 ```c++
 constexpr indirect& operator=(indirect&& other) noexcept(
@@ -827,7 +827,7 @@ constexpr indirect& operator=(indirect&& other) noexcept(
 
 _Mandates_: `is_move_constructible_v<T>` is `true`.
 
-7. _Effects_: If `&other == this`, then has no effects. Otherwise, if
+5. _Effects_: If `&other == this`, then has no effects. Otherwise, if
   `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value
   == true`, `allocator_` is set to the allocator of `other`. If allocator is
   propagated or is equal to the allocator of `other`, destroys the owned object,
@@ -835,9 +835,9 @@ _Mandates_: `is_move_constructible_v<T>` is `true`.
   destroys the owned object if any, then move constructs an object from the
   object owned by `other`.
 
-8. _Postconditions_: `*this` is not valueless. `other` is valueless.
+6. _Postconditions_: `*this` is not valueless. `other` is valueless.
 
-9. _Returns_: A reference to `*this`.
+7. _Returns_: A reference to `*this`.
 
 #### X.Y.6 Observers [indirect.observers]
 
@@ -888,7 +888,7 @@ constexpr void swap(indirect& other) noexcept(
   || allocator_traits::is_always_equal::value);
 ```
 
-2. _Effects_: Swaps the objects owned by `*this` and `other`. If
+1. _Effects_: Swaps the objects owned by `*this` and `other`. If
   `allocator_traits<allocator_type>::propagate_on_container_swap::value` is
   `true`, then `allocator_type` shall meet the _Cpp17Swappable_ requirements and
   the allocators of `*this` and `other` are exchanged by calling
@@ -901,7 +901,7 @@ constexpr void swap(indirect& lhs, indirect& rhs) noexcept(
   noexcept(lhs.swap(rhs)));
 ```
 
-4. _Effects_: Equivalent to `lhs.swap(rhs)`.
+2. _Effects_: Equivalent to `lhs.swap(rhs)`.
 
 #### X.Y.8 Relational operators [indirect.rel]
 
@@ -1272,27 +1272,27 @@ constexpr polymorphic(allocator_arg_t, const Allocator& alloc,
                       const polymorphic& other);
 ```
 
-15. _Effects_: Constructs a polymorphic owning an instance of `T` created with the
+14. _Effects_: Constructs a polymorphic owning an instance of `T` created with the
   copy constructor of the object owned by `other`. `allocator_` is
   direct-non-list-initialized with alloc.
 
-16. _Postconditions_: `*this` is not valueless.
+15. _Postconditions_: `*this` is not valueless.
 
 ```c++
 constexpr polymorphic(polymorphic&& other) noexcept;
 ```
 
-17. _Effects_: Equivalent to `polymorphic(allocator_arg_t{}, Allocator(std::move(other.alloc_)), other)`.
+16. _Effects_: Equivalent to `polymorphic(allocator_arg_t{}, Allocator(std::move(other.alloc_)), other)`.
 
 ```c++
 constexpr polymorphic(allocator_arg_t, const Allocator& alloc,
                       polymorphic&& other) noexcept;
 ```
 
-19. _Effects_: Constructs a polymorphic that takes ownership of the object owned
+17. _Effects_: Constructs a polymorphic that takes ownership of the object owned
   by `other`. `allocator_` is direct-non-list-initialized with `alloc`.
 
-20. _Postconditions_: `other` is valueless.
+18. _Postconditions_: `other` is valueless.
 
 _[Note: This constructor does not require that `is_move_constructible_v<T>`
   is `true`. --end note]_
@@ -1313,13 +1313,13 @@ constexpr ~polymorphic();
 constexpr polymorphic& operator=(const polymorphic& other);
 ```
 
-2. _Effects_: If `&other == this`, then has no effects. Otherwise, if `*this` is not
+1. _Effects_: If `&other == this`, then has no effects. Otherwise, if `*this` is not
 valueless, destroys the owned object. If
   `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
   == true`, `allocator_` is set to the allocator of `other`. Copy constructs a
   new object using the object owned by `other`.
 
-3. _Postconditions_: `*this` is not valueless.
+2. _Postconditions_: `*this` is not valueless.
 
 ```c++
 constexpr polymorphic& operator=(polymorphic&& other) noexcept(
@@ -1327,7 +1327,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
     allocator_traits<Allocator>::is_always_equal::value);
 ```
 
-5. _Effects_: If `&other == this`, then has no effects. Otherwise, if
+3. _Effects_: If `&other == this`, then has no effects. Otherwise, if
   `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value
   == true`, `allocator_` is set to the allocator of `other`. If allocator is
   propagated or is equal to the allocator of `other`, destroys the owned object
@@ -1335,7 +1335,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
   destroys the owned object if any, then move constructs an object from the
   object owned by `other`.
 
-6. _Postconditions_: `*this` is not valueless. `other` is valueless.
+4. _Postconditions_: `*this` is not valueless. `other` is valueless.
 
 #### X.Z.6 Observers [polymorphic.observers]
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1812,8 +1812,8 @@ of these changes on users could be potentially significant and unwelcome.
 |`indirect` comparsion preconditions | `indirect` must not be valueless | Allows comparison of valueless objects | Runtime cost | No |
 |`indirect` hash preconditions| `indirect` must not be valueless | Allows hash of valueless objects | Runtime cost | No |
 |`indirect` format preconditions | `indirect` must not be valueless | Allows formatting of valueless objects | Runtime cost | No |
-|Copy and copy assign preconditions| Object can valueless | Forbids copying of valueless objects | Previously valid code would invoke undefined behaviour | Yes |
-|Move and move assign preconditions| Object can valueless | Forbids moving of valueless objects | Previously valid code would invoke undefined behaviour | Yes |
+|Copy and copy assign preconditions| Object can be valueless | Forbids copying of valueless objects | Previously valid code would invoke undefined behaviour | Yes |
+|Move and move assign preconditions| Object can be valueless | Forbids moving of valueless objects | Previously valid code would invoke undefined behaviour | Yes |
 |Requirements on `T` in `polymorphic<T>` | No requirement that `T` has virtual functions | Add _Mandates_ or _Constraints_ to require `T` to have virtual functions | Code becomes ill-formed | Yes |
 |State of default-constructed object| Default-constructed object (where valid) has a value | Make default-constructed object valueless | Changes semantics; necessitates adding `operator bool` and allowing move, copy and compare of valueless (empty) objects | Yes |
 |Small buffer optimisation for polymorphic|SBO is not required, settings are hidden|Add buffer size and alignment as template parameters| Breaks ABI; forces implementers to use SBO | Yes |

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -43,6 +43,12 @@ should not be considered in isolation.
 
 ## History
 
+### Changes in R4
+
+* No longer specify constructors as uses-allocator constructing anything.
+
+* Require `T` to satisfy the requirements of `Cpp17Destructible`.
+
 ### Changes in R3
 
 * Add explicit to constructors.
@@ -483,9 +489,10 @@ value may only become valueless after it has been moved from.
 2. In every specialization `indirect<T, Allocator>`, the type
 `allocator_traits<Allocator>::value_type` shall be the same type as `T`. Every
 object of type `indirect<T, Allocator>` uses an object of type `Allocator` to
-allocate and free storage for the owned object as needed. The owned object is constructed using the function
-`allocator_traits<allocator_type>::rebind_traits<U>::construct` and destroyed
- using the function
+allocate and free storage for the owned object as needed. The owned object is
+constructed using the function
+ `allocator_traits<allocator_type>::rebind_traits<U>::construct` and destroyed
+using the function
 `allocator_traits<allocator_type>::rebind_traits<U>::destroy`, where `U` is
 either `allocator_type::value_type` or an internal type used by the indirect
 value.
@@ -516,7 +523,7 @@ move assignment, or swapping of the allocator only if
 
     is `true` within the implementation of the corresponding indirect value operation.
 
-4. The template parameter `T` of `indirect` shall be a non-union class type.
+4. The template parameter `T` of `indirect` shall meet the requirements of _Cpp17Destructible_.
 
 5. The template parameter `T` of `indirect` may be an incomplete type.
 
@@ -685,7 +692,7 @@ explicit constexpr indirect()
 
 1. _Mandates_: `is_default_constructible_v<T>` is true.
 
-2. _Effects_: Constructs an `indirect` owning a uses-allocator constructed `T`
+2. _Effects_: Constructs an `indirect` owning a default constructed `T`
   and stores the address in `p_`. `allocator_` is default constructed.
 
 3. _Postconditions_: `*this` is not valueless.
@@ -699,7 +706,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& alloc);
 
 5. _Mandates_: `is_default_constructible_v<T>` is `true`.
 
-6. _Effects_: Constructs an `indirect` owning a uses-allocator constructed `T` and
+6. _Effects_: Constructs an `indirect` owning a default constructed `T` and
   stores the address in `p_`. `allocator_` is direct-non-list-initialized with `alloc`.
 
 7. _Postconditions_: `*this` is not valueless.
@@ -731,7 +738,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& alloc, U&& u, Us&&
     DRAFTING NOTE: based on https://eel.is/c++draft/func.wrap#func.con-6
 
 13. _Postconditions_: `*this` is not valueless.  `p_` targets an object of type `T`
-  uses-allocator constructed with `std::forward<U>(u)`, `std::forward<Us>(us)...`.
+  constructed with `std::forward<U>(u)`, `std::forward<Us>(us)...`.
 
 ```c++
 constexpr indirect(const indirect& other);
@@ -1145,7 +1152,7 @@ or (64.3) `allocator_traits<allocator_type>::propagate_on_container_swap::value`
 is true within the implementation of the corresponding polymorphic value
 operation.
 
-4. The template parameter `T` of `polymorphic` shall be a non-union class type.
+4. The template parameter `T` of `polymorphic` shall meet the requirements of _Cpp17Destructible_.
 
 5. The template parameter `T` of `polymorphic` may be an incomplete type.
 
@@ -1220,7 +1227,7 @@ explicit constexpr polymorphic()
 1. _Mandates_: `is_default_constructible_v<T>` is `true`,
   `is_copy_constructible_v<T>` is `true`.
 
-2. _Effects_: Constructs a polymorphic owning a uses-allocator constructed `T`.
+2. _Effects_: Constructs a polymorphic owning a default constructed `T`.
   `allocator_` is default constructed.
 
 3. _Postconditions_: `*this` is not valueless.
@@ -1235,7 +1242,7 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& alloc);
 5. _Mandates_: `is_default_constructible_v<T>` is `true`,
   `is_copy_constructible_v<T>` is `true`.
 
-6. _Effects_: Constructs a polymorphic owning a uses-allocator constructed `T`.
+6. _Effects_: Constructs a polymorphic owning a default constructed `T`.
    `allocator_` is direct-non-list-initialized with alloc.
 
 7. _Postconditions_: `*this` is not valueless.
@@ -1262,7 +1269,7 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& alloc,
 11. _Effects_: `allocator_` is direct-non-list-initialized with alloc.
 
 12. _Postconditions_: `*this` is not valueless.  The owned instance targets an object of type `U`
-  uses-allocator constructed  with `std::forward<Ts>(ts)...`.
+  constructed  with `std::forward<Ts>(ts)...`.
 
 ```c++
 constexpr polymorphic(const polymorphic& other);

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -45,6 +45,8 @@ should not be considered in isolation.
 
 ### Changes in R4
 
+* Allow copy and move of valueless objects, discuss similarities with variant.
+
 * No longer specify constructors as uses-allocator constructing anything.
 
 * Require `T` to satisfy the requirements of `Cpp17Destructible`.
@@ -380,6 +382,25 @@ valueless state would necessitate the addition of an otherwise redundant check.
 Accessing a valueless `indirect` is undefined behaviour, so we make it a
 precondition for comparison and hash that the instance of `indirect` is not
 valueless.
+
+Variant allows valueless objects to be passed around via copy, assignment, move
+and move assignment. There is no precondition on varaint that it must not be in
+a valuless state to be copied from, moved from, assigned from or move assigned
+from. While the notion that a valueless `indirect` or `polymorphic` is toxic and
+must not be passed around code is appealing, it would not interact well with
+generic code which may need to handle a variety of types. Note that the standard
+does not require a moved-from object to be valid for copy, move, assign or move
+assignment: the only restriction is that it should be in a well-formed but
+unspecified state. However, there is no precedent for standard library types to
+have preconditions on move, copy, assign or move assignment. We opt for
+consistency with existing standard library types (namely varaint which has a
+valueless state) and allow copy, move, assignment and move assignment of a
+valuless `indirect` and `polymorphic`. Handling of the valueless state for
+indirect and polymorphic in move operations will not incur cost; for copy
+operations, the cost of handling the valuless state will be insignificant
+compared to the cost of allocating memory. Introducing preconditions for copy,
+move, assign and move assign in a later revision of the C++ standard would be a
+silent breaking change.
 
 ### `noexcept` and narrow contracts
 
@@ -1798,8 +1819,8 @@ of these changes on users could be potentially significant and unwelcome.
 |`indirect` comparsion preconditions | `indirect` must not be valueless | Allows comparison of valueless objects | Runtime cost | No |
 |`indirect` hash preconditions| `indirect` must not be valueless | Allows hash of valueless objects | Runtime cost | No |
 |`indirect` format preconditions | `indirect` must not be valueless | Allows formatting of valueless objects | Runtime cost | No |
-|Copy and copy assign preconditions| Object must not be valueless | Allows copying of valueless objects | Runtime cost | No |
-|Move and move assign preconditions| Object must not be valueless | Allows moving of valueless objects | Runtime cost | No |
+|Copy and copy assign preconditions| Object can valueless | Forbids copying of valueless objects | Previously valid code would invoke undefined behaviour | Yes |
+|Move and move assign preconditions| Object can valueless | Forbids moving of valueless objects | Previously valid code would invoke undefined behaviour | Yes |
 |Requirements on `T` in `polymorphic<T>` | No requirement that `T` has virtual functions | Add _Mandates_ or _Constraints_ to require `T` to have virtual functions | Code becomes ill-formed | Yes |
 |State of default-constructed object| Default-constructed object (where valid) has a value | Make default-constructed object valueless | Changes semantics; necessitates adding `operator bool` and allowing move, copy and compare of valueless (empty) objects | Yes |
 |Small buffer optimisation for polymorphic|SBO is not required, settings are hidden|Add buffer size and alignment as template parameters| Breaks ABI; forces implementers to use SBO | Yes |

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -26,16 +26,14 @@ correctly generate special member functions.
 
 The class template `indirect` confers value-like semantics on a
 free-store-allocated object. An `indirect` may hold an object of a class `T`.
-Copying the `indirect` will copy the object `T`. When a parent object contains a
-member of type `indirect<T>` and is accessed through a const access path,
-`const`ness will propagate from the parent object to the instance of `T` owned
-by the `indirect` member.
+Copying the `indirect` will copy the object `T`. When an `indirect<T>` is accessed through a const access path,
+constness will propagate to the owned object.
 
 The class template `polymorphic` confers value-like semantics on a
 dynamically-allocated object.  A `polymorphic<T>` may hold an object of a class
 publicly derived from `T`. Copying the `polymorphic<T>` will copy the object of
-the derived type. A const `polymorphic<T>` propagates the constness to the owned
-`T`.
+the derived type. When a `polymorphic<T>` is accessed through a const access path,
+constness will propagate to the owned object.
 
 This proposal is a fusion of two earlier individual proposals, P1950 and P0201.
 The design of the two proposed class templates is sufficiently similar that they
@@ -159,8 +157,7 @@ by the owned object type `T`.
 * `indirect<T, Alloc>` and `polymorphic<T, Alloc>` are default constructible in
   cases where `T` is default constructible.
 
-* `indirect<T, Alloc>` is copy constructible where `T` is copy constructible and
-  assignable.
+* `indirect<T, Alloc>` is copy constructible and assignable where `T` is copy constructible and assignable.
 
 * `polymorphic<T, Alloc>` is unconditionally copy constructible and assignable.
 
@@ -243,7 +240,7 @@ Operations on a const-qualified object do not make changes to the object's
 logical state nor to the logical state of other objects.
 
 `indirect<T>` and `polymorphic<T>` are default constructible in cases where `T`
-is default constructible. Moving a value type onto the free store should not add
+is default constructible. Moving a value type into dynamically allocated storage should not add
 or remove the ability to be default constructed.
 
 Note that due to the requirement to support incomplete `T` types, the
@@ -275,11 +272,6 @@ is recommended. This may become common practice since `indirect` and
 currently used to (mis)represent component objects. Putting `T` onto the free
 store should not make it nullable. Nullability must be explicitly opted into by
 using `std::optional<indirect<T>>` or `std::optional<polymorphic<T>>`.
-
-We invite implementers to optimise their implementation of `optional<indirect>`
-and `optional<polymorphic>` to exploit the non-observable nature of the
-valueless state and minimise the size of an `optional<indirect>` or
-`optional<polymorphic>`.
 
 ### Allocator support
 
@@ -390,7 +382,7 @@ valueless.
 
 Variant allows valueless objects to be passed around via copy, assignment, move
 and move assignment. There is no precondition on varaint that it must not be in
-a valuless state to be copied from, moved from, assigned from or move assigned
+a valueless state to be copied from, moved from, assigned from or move assigned
 from. While the notion that a valueless `indirect` or `polymorphic` is toxic and
 must not be passed around code is appealing, it would not interact well with
 generic code which may need to handle a variety of types. Note that the standard

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -91,7 +91,7 @@ should not be considered in isolation.
 
 * Specify constructors as uses-allocator constructing `T`.
 
-* Wording review and additions to <memory> synopsis [memory.syn]
+* Wording review and additions to `<memory>` synopsis [memory.syn]
 
 ### Changes in R2
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -782,16 +782,13 @@ constexpr indirect(allocator_arg_t, const Allocator& alloc,
 
 18. _Effects_: Equivalent to `indirect(allocator_arg, alloc, *other)`.
 
-19. _Postconditions_: `*this` is not valueless.
-
 ```c++
 constexpr indirect(indirect&& other) noexcept;
 ```
 
-20. _Effects_: Constructs an `indirect` that takes ownership of the `other`'s owned object and stores the address in `p_`.
-  `allocator_` is initialized by construction from `other.allocator_`.
-
-21. _Postconditions_: `other` is valueless.
+19. _Effects_: Constructs an `indirect` that takes ownership of the `other`'s
+    owned object and stores the address in `p_`. `allocator_` is initialized by
+    construction from `other.allocator_`.
 
 _[Note: This constructor does not require that `is_move_constructible_v<T>`
   is `true` --end note]_
@@ -801,10 +798,8 @@ constexpr indirect(allocator_arg_t, const Allocator& alloc, indirect&& other)
   noexcept(allocator_traits<Allocator>::is_always_equal);
 ```
 
-22. _Effects_: If `alloc == other.get_allocator()` is `true` then equivalent to `indirect(std::move(other))`,
+20. _Effects_: If `alloc == other.get_allocator()` is `true` then equivalent to `indirect(std::move(other))`,
   otherwise, equivalent to `indirect(allocator_arg, alloc, *std::move(other))`.
-
-23. _Postconditions_: `other` is valueless.
 
 _[Note: This constructor does not require that `is_move_constructible_v<T>` is `true` --end note]_
 
@@ -837,9 +832,7 @@ constexpr indirect& operator=(const indirect& other);
   Otherwise, equivalent to:
   - `(allocator_traits<allocator_type>::destruct(alloc, p), allocator_traits<allocator_type>::construct(a, p, *other))`
 
-3. _Postconditions_: `*this` is not valueless.
-
-4. _Returns_: A reference to `*this`.
+3. _Returns_: A reference to `*this`.
 
 ```c++
 constexpr indirect& operator=(indirect&& other) noexcept(
@@ -849,7 +842,7 @@ constexpr indirect& operator=(indirect&& other) noexcept(
 
 _Mandates_: `is_move_constructible_v<T>` is `true`.
 
-5. _Effects_: If `&other == this`, then has no effects. Otherwise, if
+4. _Effects_: If `&other == this`, then has no effects. Otherwise, if
   `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value
   == true`, `alloc` is set to the allocator of `other`. If allocator is
   propagated or is equal to the allocator of `other`, destroys the owned object,
@@ -857,9 +850,9 @@ _Mandates_: `is_move_constructible_v<T>` is `true`.
   destroys the owned object if any, then move constructs an object from the
   object owned by `other`.
 
-6. _Postconditions_: `*this` is not valueless. `other` is valueless.
+5. _Postconditions_: `other` is valueless.
 
-7. _Returns_: A reference to `*this`.
+6. _Returns_: A reference to `*this`.
 
 #### X.Y.6 Observers [indirect.observers]
 
@@ -1299,23 +1292,19 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
   copy constructor of the object owned by `other`. `allocator_` is
   direct-non-list-initialized with alloc.
 
-15. _Postconditions_: `*this` is not valueless.
-
 ```c++
 constexpr polymorphic(polymorphic&& other) noexcept;
 ```
 
-16. _Effects_: Equivalent to `polymorphic(allocator_arg_t{}, Allocator(std::move(other.alloc_)), other)`.
+15. _Effects_: Equivalent to `polymorphic(allocator_arg_t{}, Allocator(std::move(other.alloc_)), other)`.
 
 ```c++
 constexpr polymorphic(allocator_arg_t, const Allocator& a,
                       polymorphic&& other) noexcept;
 ```
 
-17. _Effects_: Constructs a polymorphic that takes ownership of the object owned
+16. _Effects_: Constructs a polymorphic that takes ownership of the object owned
   by `other`. `allocator_` is direct-non-list-initialized with `alloc`.
-
-18. _Postconditions_: `other` is valueless.
 
 _[Note: This constructor does not require that `is_move_constructible_v<T>`
   is `true`. --end note]_
@@ -1336,13 +1325,12 @@ constexpr ~polymorphic();
 constexpr polymorphic& operator=(const polymorphic& other);
 ```
 
-1. _Effects_: If `&other == this`, then has no effects. Otherwise, if `*this` is not
-valueless, destroys the owned object. If
+1. _Effects_: If `&other == this`, then has no effects. Otherwise, if `*this` is
+not valueless, destroys the owned object. If
   `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
-  == true`, `allocator_` is set to the allocator of `other`. Copy constructs a
-  new object using the object owned by `other`.
-
-2. _Postconditions_: `*this` is not valueless.
+  == true`, `allocator_` is set to the allocator of `other`. If `other` is not
+  valueless, copy constructs a new object using the object owned by `other`.
+  Otherwise `*this` becomes valueless.
 
 ```c++
 constexpr polymorphic& operator=(polymorphic&& other) noexcept(
@@ -1350,7 +1338,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
     allocator_traits<Allocator>::is_always_equal::value);
 ```
 
-3. _Effects_: If `&other == this`, then has no effects. Otherwise, if
+2. _Effects_: If `&other == this`, then has no effects. Otherwise, if
   `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value
   == true`, `allocator_` is set to the allocator of `other`. If allocator is
   propagated or is equal to the allocator of `other`, destroys the owned object
@@ -1358,7 +1346,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
   destroys the owned object if any, then move constructs an object from the
   object owned by `other`.
 
-4. _Postconditions_: `*this` is not valueless. `other` is valueless.
+3. _Postconditions_: `other` is valueless.
 
 #### X.Z.6 Observers [polymorphic.observers]
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -746,8 +746,6 @@ constexpr indirect(const indirect& other);
 
 14. _Mandates_: `is_copy_constructible_v<T>` is `true`.
 
-15. _Preconditions_: `other` is not valueless.
-
 16. _Effects_: Equivalent to
   `indirect(allocator_arg, allocator_traits<allocator_type>::select_on_container_copy_construction(other.get_allocator()), *other)`.
 `
@@ -760,8 +758,6 @@ constexpr indirect(allocator_arg_t, const Allocator& alloc,
 
 18. _Mandates_: `is_copy_constructible_v<T>` is `true`.
 
-19. _Preconditions_: `other` is not valueless.
-
 20. _Effects_: Equivalent to `indirect(allocator_arg, alloc, *other)`.
 
 21. _Postconditions_: `*this` is not valueless.
@@ -770,26 +766,25 @@ constexpr indirect(allocator_arg_t, const Allocator& alloc,
 constexpr indirect(indirect&& other) noexcept;
 ```
 
-22. _Preconditions_: `other` is not valueless. _[Note: This constructor does not require that `is_move_constructible_v<T>`
-  is `true` --end note]_
-
 23. _Effects_: Constructs an `indirect` that takes ownership of the `other`'s owned object and stores the address in `p_`.
   `allocator_` is initialized by construction from `other.allocator_`.
 
 24. _Postconditions_: `other` is valueless.
+
+_[Note: This constructor does not require that `is_move_constructible_v<T>`
+  is `true` --end note]_
 
 ```c++
 constexpr indirect(allocator_arg_t, const Allocator& alloc, indirect&& other)
   noexcept(allocator_traits<Allocator>::is_always_equal);
 ```
 
-25. _Preconditions_: `other` is not valueless. _[Note: This constructor does not require that `is_move_constructible_v<T>`
-  is `true` --end note]_
-
 26. _Effects_: If `alloc == other.get_allocator()` is `true` then equivalent to `indirect(std::move(other))`,
   otherwise, equivalent to `indirect(allocator_arg, alloc, *std::move(other))`.
 
 27. _Postconditions_: `other` is valueless.
+
+_[Note: This constructor does not require that `is_move_constructible_v<T>` is `true` --end note]_
 
 #### X.Y.4 Destructor [indirect.dtor]
 
@@ -808,8 +803,6 @@ constexpr indirect& operator=(const indirect& other);
 ```
 
 1. _Mandates_: `is_copy_constructible_v<T>` is `true`.
-
-2. _Preconditions_: `other` is not valueless.
 
 3. _Effects_: If `this == &other` is `true`, then has no effects.
   Otherwise, if either:
@@ -833,8 +826,6 @@ constexpr indirect& operator=(indirect&& other) noexcept(
 ```
 
 _Mandates_: `is_move_constructible_v<T>` is `true`.
-
-6. _Preconditions_: `other` is not valueless.
 
 7. _Effects_: If `&other == this`, then has no effects. Otherwise, if
   `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value
@@ -896,8 +887,6 @@ constexpr void swap(indirect& other) noexcept(
   allocator_traits::propagate_on_container_swap::value
   || allocator_traits::is_always_equal::value);
 ```
-
-1. _Preconditions_: `*this` is not valueless, `other` is not valueless.
 
 2. _Effects_: Swaps the objects owned by `*this` and `other`. If
   `allocator_traits<allocator_type>::propagate_on_container_swap::value` is
@@ -1283,10 +1272,9 @@ constexpr polymorphic(allocator_arg_t, const Allocator& alloc,
                       const polymorphic& other);
 ```
 
-14. _Preconditions_: `other` is not valueless.
-
 15. _Effects_: Constructs a polymorphic owning an instance of `T` created with the
-  copy constructor of the object owned by `other`. `allocator_` is direct-non-list-initialized with alloc.
+  copy constructor of the object owned by `other`. `allocator_` is
+  direct-non-list-initialized with alloc.
 
 16. _Postconditions_: `*this` is not valueless.
 
@@ -1301,14 +1289,13 @@ constexpr polymorphic(allocator_arg_t, const Allocator& alloc,
                       polymorphic&& other) noexcept;
 ```
 
-18. _Preconditions_: `other` is not valueless. _[Note: This constructor does not require that `is_move_constructible_v<T>`
-  is `true`. --end note]_
-
 19. _Effects_: Constructs a polymorphic that takes ownership of the object owned
-  by `other`.
-  `allocator_` is direct-non-list-initialized with `alloc`.
+  by `other`. `allocator_` is direct-non-list-initialized with `alloc`.
 
 20. _Postconditions_: `other` is valueless.
+
+_[Note: This constructor does not require that `is_move_constructible_v<T>`
+  is `true`. --end note]_
 
 #### X.Z.4 Destructor [polymorphic.dtor]
 
@@ -1326,8 +1313,6 @@ constexpr ~polymorphic();
 constexpr polymorphic& operator=(const polymorphic& other);
 ```
 
-1. _Preconditions_: `other` is not valueless.
-
 2. _Effects_: If `&other == this`, then has no effects. Otherwise, if `*this` is not
 valueless, destroys the owned object. If
   `allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value
@@ -1341,8 +1326,6 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
     allocator_traits<Allocator>::propagate_on_container_move_assignment::value ||
     allocator_traits<Allocator>::is_always_equal::value);
 ```
-
-4. _Preconditions_: `other` is not valueless.
 
 5. _Effects_: If `&other == this`, then has no effects. Otherwise, if
   `allocator_traits<allocator_type>::propagate_on_container_move_assignment::value
@@ -1393,10 +1376,7 @@ constexpr void swap(polymorphic& other) noexcept(
   allocator_traits::propagate_on_container_swap::value
   || allocator_traits::is_always_equal::value);
 ```
-
-1. _Preconditions_: `*this` is not valueless, `other` is not valueless.
-
-2. _Effects_: Swaps the objects owned by `*this` and `other`. If
+1. _Effects_: Swaps the objects owned by `*this` and `other`. If
   `allocator_traits<allocator_type>::propagate_on_container_swap::value` is
   `true`, then `allocator_type` shall meet the _Cpp17Swappable_ requirements and
   the allocators of `*this` and `other` are exchanged by calling
@@ -1410,7 +1390,7 @@ constexpr void swap(polymorphic& lhs, polymorphic& rhs) noexcept(
   noexcept(lhs.swap(rhs)));
 ```
 
-3. _Effects_: Equivalent to `lhs.swap(rhs)`.
+2. _Effects_: Equivalent to `lhs.swap(rhs)`.
 
 ## Reference implementation
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1455,10 +1455,6 @@ the discriminant must be stored.
 For the sake of minimal size and efficiency, we opted to use two class
 templates.
 
-### A null state or a valueless state
-
-TODO: discuss the tradeoffs between an observable null state and a valueless state.
-
 ### Copiers, deleters, pointer constructors, and allocator support
 
 The older types `indirect_value` and `polymorphic_value` had constructors that

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -26,8 +26,9 @@ correctly generate special member functions.
 
 The class template `indirect` confers value-like semantics on a
 free-store-allocated object. An `indirect` may hold an object of a class `T`.
-Copying the `indirect` will copy the object `T`. When an `indirect<T>` is accessed through a const access path,
-constness will propagate to the owned object.
+Copying the `indirect` will copy the object `T`. When an `indirect<T>` is
+accessed through a const access path, constness will propagate to the owned
+object.
 
 The class template `polymorphic` confers value-like semantics on a
 dynamically-allocated object.  A `polymorphic<T>` may hold an object of a class

--- a/indirect.h
+++ b/indirect.h
@@ -148,11 +148,10 @@ class indirect {
       reset();
       return *this;
     }
-    if (alloc_ == other.alloc_ && std::is_copy_assignable_v<T>) {
-      if (p_ != nullptr) {
-        *p_ = *other.p_;
-        return *this;
-      }
+    if (alloc_ == other.alloc_ && std::is_copy_assignable_v<T> &&
+        p_ != nullptr) {
+      *p_ = *other.p_;
+      return *this;
     }
     reset();  // We may not have reset above and it's a no-op if valueless.
     p_ = construct_from(alloc_, *other);

--- a/indirect.h
+++ b/indirect.h
@@ -185,32 +185,32 @@ class indirect {
   }
 
   constexpr const T& operator*() const& noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return *p_;
   }
 
   constexpr T& operator*() & noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return *p_;
   }
 
   constexpr T&& operator*() && noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return std::move(*p_);
   }
 
   constexpr const T&& operator*() const&& noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return std::move(*p_);
   }
 
   constexpr const_pointer operator->() const noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return p_;
   }
 
   constexpr pointer operator->() noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return p_;
   }
 

--- a/indirect.h
+++ b/indirect.h
@@ -102,7 +102,6 @@ class indirect {
       : alloc_(allocator_traits::select_on_container_copy_construction(
             other.alloc_)) {
     static_assert(std::is_copy_constructible_v<T>);
-    assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     p_ = construct_from(alloc_, *other);
   }
 
@@ -110,13 +109,11 @@ class indirect {
                      const indirect& other)
       : alloc_(alloc) {
     static_assert(std::is_copy_constructible_v<T>);
-    assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     p_ = construct_from(alloc_, *other);
   }
 
   constexpr indirect(indirect&& other) noexcept
       : p_(nullptr), alloc_(other.alloc_) {
-    assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     std::swap(p_, other.p_);
   }
 
@@ -124,7 +121,6 @@ class indirect {
       std::allocator_arg_t, const A& alloc,
       indirect&& other) noexcept(allocator_traits::is_always_equal::value)
       : p_(nullptr), alloc_(alloc) {
-    assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     std::swap(p_, other.p_);
   }
 
@@ -132,7 +128,6 @@ class indirect {
 
   constexpr indirect& operator=(const indirect& other) {
     if (this == &other) return *this;
-    assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     static_assert(std::is_copy_constructible_v<T>);
     static_assert(std::is_copy_assignable_v<T>);
     if constexpr (allocator_traits::propagate_on_container_copy_assignment::
@@ -157,7 +152,6 @@ class indirect {
       allocator_traits::propagate_on_container_move_assignment::value ||
       allocator_traits::is_always_equal::value) {
     if (this == &other) return *this;
-    assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     static_assert(std::is_copy_constructible_v<T>);
 
     if constexpr (allocator_traits::propagate_on_container_move_assignment::
@@ -213,8 +207,6 @@ class indirect {
   constexpr void swap(indirect& other) noexcept(
       std::allocator_traits<A>::propagate_on_container_swap::value ||
       std::allocator_traits<A>::is_always_equal::value) {
-    assert(p_ != nullptr);        // LCOV_EXCL_LINE
-    assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
     if constexpr (allocator_traits::propagate_on_container_swap::value) {
       // If allocators move with their allocated objects, we can swap both.
       std::swap(alloc_, other.alloc_);

--- a/indirect_cxx14.h
+++ b/indirect_cxx14.h
@@ -188,7 +188,7 @@ class indirect : private detail::empty_base_optimization<A> {
       }
     }
     if (alloc_base::get() == other.alloc_base::get()) {
-      if (p_ != nullptr) {
+      if (p_ != nullptr && !other.valueless_after_move()) {
         *p_ = *other.p_;
         return *this;
       }
@@ -196,9 +196,9 @@ class indirect : private detail::empty_base_optimization<A> {
     reset();  // We may not have reset above and it's a no-op if valueless.
     if (other.valueless_after_move()) {
       p_ = nullptr;
-      return *this;
+    } else {
+      p_ = construct_from(alloc_base::get(), *other);
     }
-    p_ = construct_from(alloc_base::get(), *other);
     return *this;
   }
 

--- a/indirect_cxx14.h
+++ b/indirect_cxx14.h
@@ -267,9 +267,6 @@ class indirect : private detail::empty_base_optimization<A> {
   void swap(indirect& other) noexcept(
       std::allocator_traits<A>::propagate_on_container_swap::value ||
       std::allocator_traits<A>::is_always_equal::value) {
-    assert(p_ != nullptr);        // LCOV_EXCL_LINE
-    assert(other.p_ != nullptr);  // LCOV_EXCL_LINE
-
     if (allocator_traits::propagate_on_container_swap::value) {
       // If allocators move with their allocated objects we can swap both.
       std::swap(alloc_base::get(), other.alloc_base::get());

--- a/indirect_cxx14.h
+++ b/indirect_cxx14.h
@@ -191,18 +191,12 @@ class indirect : private detail::empty_base_optimization<A> {
       return *this;
     }
     if (alloc_base::get() == other.alloc_base::get() &&
-        std::is_copy_assignable<T>::value) {
-      if (p_ != nullptr && !other.valueless_after_move()) {
-        *p_ = *other.p_;
-        return *this;
-      }
+        std::is_copy_assignable<T>::value && p_ != nullptr) {
+      *p_ = *other.p_;
+      return *this;
     }
     reset();  // We may not have reset above and it's a no-op if valueless.
-    if (other.valueless_after_move()) {
-      p_ = nullptr;
-    } else {
-      p_ = construct_from(alloc_base::get(), *other);
-    }
+    p_ = construct_from(alloc_base::get(), *other);
     return *this;
   }
 

--- a/indirect_cxx14.h
+++ b/indirect_cxx14.h
@@ -231,32 +231,32 @@ class indirect : private detail::empty_base_optimization<A> {
   }
 
   const T& operator*() const& noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return *p_;
   }
 
   T& operator*() & noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return *p_;
   }
 
   T&& operator*() && noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return std::move(*p_);
   }
 
   const T&& operator*() const&& noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return std::move(*p_);
   }
 
   const_pointer operator->() const noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return p_;
   }
 
   pointer operator->() noexcept {
-    assert(p_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return p_;
   }
 

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -233,7 +233,8 @@ TEST(IndirectTest, SwapFromValueless) {
   xyz::indirect<int> b;
   EXPECT_TRUE(!b.valueless_after_move());
 
-  std::swap(a, b);
+  using std::swap;
+  swap(a, b);
   EXPECT_TRUE(!a.valueless_after_move());
   EXPECT_TRUE(b.valueless_after_move());
 }

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -187,6 +187,56 @@ TEST(IndirectTest, MemberSwapWithSelf) {
   EXPECT_FALSE(a.valueless_after_move());
 }
 
+TEST(IndirectTest, CopyFromValueless) {
+  xyz::indirect<int> a;
+  xyz::indirect<int> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::indirect<int> b(a);
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(IndirectTest, MoveFromValueless) {
+  xyz::indirect<int> a;
+  xyz::indirect<int> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::indirect<int> b(std::move(a));
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(IndirectTest, AssignFromValueless) {
+  xyz::indirect<int> a;
+  xyz::indirect<int> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::indirect<int> b = a;
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(IndirectTest, MoveAssignFromValueless) {
+  xyz::indirect<int> a;
+  xyz::indirect<int> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::indirect<int> b;
+  b = std::move(a);
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(IndirectTest, SwapFromValueless) {
+  xyz::indirect<int> a;
+  xyz::indirect<int> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::indirect<int> b;
+  EXPECT_TRUE(!b.valueless_after_move());
+
+  std::swap(a, b);
+  EXPECT_TRUE(!a.valueless_after_move());
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
 TEST(IndirectTest, ConstPropagation) {
   struct SomeType {
     enum class Constness { LV_CONST, LV_NON_CONST, RV_CONST, RV_NON_CONST };

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -128,6 +128,22 @@ TEST(IndirectTest, MovePreservesIndirectObjectAddress) {
   EXPECT_EQ(address, &*aa);
 }
 
+TEST(IndirectTest, AllocatorExtendedCopy) {
+  xyz::indirect<int> a(42);
+  xyz::indirect<int> aaa(std::allocator_arg, a.get_allocator(), a);
+  EXPECT_EQ(*a, *aa);
+  EXPECT_NE(&*a, &*aa);
+}
+
+TEST(IndirectTest, AllocatorExtendedMove) {
+  xyz::indirect<int> a(42);
+  auto address = &*a;
+  xyz::indirect<int> aa(std::allocator_arg, a.get_allocator(), std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  EXPECT_EQ(address, &*aa);
+}
+
 TEST(IndirectTest, CopyAssignment) {
   xyz::indirect<int> a(42);
   xyz::indirect<int> b(101);

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -205,6 +205,24 @@ TEST(IndirectTest, MoveFromValueless) {
   EXPECT_TRUE(b.valueless_after_move());
 }
 
+TEST(IndirectTest, AllocatorExtendedCopyFromValueless) {
+  xyz::indirect<int> a;
+  xyz::indirect<int> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::indirect<int> b(std::allocator_arg, a.get_allocator(), a);
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(IndirectTest, AllocatorExtendedMoveFromValueless) {
+  xyz::indirect<int> a;
+  xyz::indirect<int> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::indirect<int> b(std::allocator_arg, a.get_allocator(), std::move(a));
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
 TEST(IndirectTest, AssignFromValueless) {
   xyz::indirect<int> a;
   xyz::indirect<int> aa(std::move(a));

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -130,7 +130,7 @@ TEST(IndirectTest, MovePreservesIndirectObjectAddress) {
 
 TEST(IndirectTest, AllocatorExtendedCopy) {
   xyz::indirect<int> a(42);
-  xyz::indirect<int> aaa(std::allocator_arg, a.get_allocator(), a);
+  xyz::indirect<int> aa(std::allocator_arg, a.get_allocator(), a);
   EXPECT_EQ(*a, *aa);
   EXPECT_NE(&*a, &*aa);
 }

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -210,7 +210,8 @@ TEST(IndirectTest, AssignFromValueless) {
   xyz::indirect<int> aa(std::move(a));
 
   EXPECT_TRUE(a.valueless_after_move());
-  xyz::indirect<int> b = a;
+  xyz::indirect<int> b;
+  b = a;
   EXPECT_TRUE(b.valueless_after_move());
 }
 

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -190,13 +190,21 @@ class polymorphic {
   constexpr polymorphic(const polymorphic& other)
       : alloc_(allocator_traits::select_on_container_copy_construction(
             other.alloc_)) {
-    cb_ = other.cb_->clone(alloc_);
+    if (!other.valueless_after_move()) {
+      cb_ = other.cb_->clone(alloc_);
+    } else {
+      cb_ = nullptr;
+    }
   }
 
   constexpr polymorphic(std::allocator_arg_t, const A& alloc,
                         const polymorphic& other)
       : alloc_(alloc) {
-    cb_ = other.cb_->clone(alloc_);
+    if (!other.valueless_after_move()) {
+      cb_ = other.cb_->clone(alloc_);
+    } else {
+      cb_ = nullptr;
+    }
   }
 
   constexpr polymorphic(polymorphic&& other) noexcept : alloc_(other.alloc_) {

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -190,19 +190,16 @@ class polymorphic {
   constexpr polymorphic(const polymorphic& other)
       : alloc_(allocator_traits::select_on_container_copy_construction(
             other.alloc_)) {
-    assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
     cb_ = other.cb_->clone(alloc_);
   }
 
   constexpr polymorphic(std::allocator_arg_t, const A& alloc,
                         const polymorphic& other)
       : alloc_(alloc) {
-    assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
     cb_ = other.cb_->clone(alloc_);
   }
 
   constexpr polymorphic(polymorphic&& other) noexcept : alloc_(other.alloc_) {
-    assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
     cb_ = std::exchange(other.cb_, nullptr);
   }
 
@@ -210,7 +207,6 @@ class polymorphic {
       std::allocator_arg_t, const A& alloc,
       polymorphic&& other) noexcept(allocator_traits::is_always_equal::value)
       : alloc_(alloc) {
-    assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
     cb_ = std::exchange(other.cb_, nullptr);
   }
 
@@ -218,7 +214,6 @@ class polymorphic {
 
   constexpr polymorphic& operator=(const polymorphic& other) {
     if (this == &other) return *this;
-    assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
     if constexpr (allocator_traits::propagate_on_container_copy_assignment::
                       value) {
       if (alloc_ != other.alloc_) {
@@ -235,7 +230,6 @@ class polymorphic {
       allocator_traits::propagate_on_container_move_assignment::value ||
       allocator_traits::is_always_equal::value) {
     if (this == &other) return *this;
-    assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
     if constexpr (allocator_traits::propagate_on_container_move_assignment::
                       value) {
       if (alloc_ != other.alloc_) {
@@ -281,8 +275,6 @@ class polymorphic {
   constexpr void swap(polymorphic& other) noexcept(
       std::allocator_traits<A>::propagate_on_container_swap::value ||
       std::allocator_traits<A>::is_always_equal::value) {
-    assert(cb_ != nullptr);        // LCOV_EXCL_LINE
-    assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
     if constexpr (allocator_traits::propagate_on_container_swap::value) {
       // If allocators move with their allocated objects, we can swap both.
       std::swap(alloc_, other.alloc_);

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -263,22 +263,22 @@ class polymorphic {
   }
 
   constexpr pointer operator->() noexcept {
-    assert(cb_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return cb_->p_;
   }
 
   constexpr const_pointer operator->() const noexcept {
-    assert(cb_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return cb_->p_;
   }
 
   constexpr T& operator*() noexcept {
-    assert(cb_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return *cb_->p_;
   }
 
   constexpr const T& operator*() const noexcept {
-    assert(cb_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return *cb_->p_;
   }
 

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -230,7 +230,11 @@ class polymorphic {
       }
     }
     reset();  // We may not have reset above and it's a no-op if valueless.
-    cb_ = other.cb_->clone(alloc_);
+    if (!other.valueless_after_move()) {
+      cb_ = other.cb_->clone(alloc_);
+    } else {
+      cb_ = nullptr;
+    }
     return *this;
   }
 
@@ -249,7 +253,11 @@ class polymorphic {
     if (alloc_ == other.alloc_) {
       std::swap(cb_, other.cb_);
     } else {
-      cb_ = other.cb_->clone(alloc_);
+      if (!other.valueless_after_move()) {
+        cb_ = other.cb_->clone(alloc_);
+      } else {
+        cb_ = nullptr;
+      }
     }
     return *this;
   }

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -230,11 +230,10 @@ class polymorphic {
       }
     }
     reset();  // We may not have reset above and it's a no-op if valueless.
-    if (!other.valueless_after_move()) {
-      cb_ = other.cb_->clone(alloc_);
-    } else {
-      cb_ = nullptr;
+    if (other.valueless_after_move()) {
+      return *this;
     }
+    cb_ = other.cb_->clone(alloc_);
     return *this;
   }
 
@@ -250,14 +249,13 @@ class polymorphic {
       }
     }
     reset();  // We may not have reset above and it's a no-op if valueless.
+    if (other.valueless_after_move()) {
+      return *this;
+    }
     if (alloc_ == other.alloc_) {
       std::swap(cb_, other.cb_);
     } else {
-      if (!other.valueless_after_move()) {
-        cb_ = other.cb_->clone(alloc_);
-      } else {
-        cb_ = nullptr;
-      }
+      cb_ = other.cb_->clone(alloc_);
     }
     return *this;
   }

--- a/polymorphic_cxx14.h
+++ b/polymorphic_cxx14.h
@@ -298,22 +298,22 @@ class polymorphic : private detail::empty_base_optimization<A> {
   }
 
   pointer operator->() noexcept {
-    assert(cb_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return cb_->p_;
   }
 
   const_pointer operator->() const noexcept {
-    assert(cb_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return cb_->p_;
   }
 
   T& operator*() noexcept {
-    assert(cb_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return *cb_->p_;
   }
 
   const T& operator*() const noexcept {
-    assert(cb_ != nullptr);  // LCOV_EXCL_LINE
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
     return *cb_->p_;
   }
 

--- a/polymorphic_cxx14.h
+++ b/polymorphic_cxx14.h
@@ -266,11 +266,10 @@ class polymorphic : private detail::empty_base_optimization<A> {
       }
     }
     reset();  // We may not have reset above and it's a no-op if valueless.
-    if (!other.valueless_after_move()) {
-      cb_ = other.cb_->clone(alloc_base::get());
-    } else {
-      cb_ = nullptr;
+    if (other.valueless_after_move()) {
+      return *this;
     }
+    cb_ = other.cb_->clone(alloc_base::get());
     return *this;
   }
 
@@ -285,14 +284,13 @@ class polymorphic : private detail::empty_base_optimization<A> {
       }
     }
     reset();  // We may not have reset above and it's a no-op if valueless.
+    if (other.valueless_after_move()) {
+      return *this;
+    }
     if (alloc_base::get() == other.alloc_base::get()) {
       std::swap(cb_, other.cb_);
     } else {
-      if (!other.valueless_after_move()) {
-        cb_ = other.cb_->clone(alloc_base::get());
-      } else {
-        cb_ = nullptr;
-      }
+      cb_ = other.cb_->clone(alloc_base::get());
     }
     return *this;
   }

--- a/polymorphic_cxx14.h
+++ b/polymorphic_cxx14.h
@@ -259,7 +259,6 @@ class polymorphic : private detail::empty_base_optimization<A> {
 
   polymorphic& operator=(const polymorphic& other) {
     if (this == &other) return *this;
-    assert(other.cb_ != nullptr);  // LCOV_EXCL_LINE
     if (allocator_traits::propagate_on_container_copy_assignment::value) {
       if (alloc_base::get() != other.alloc_base::get()) {
         reset();  // using current allocator.

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -211,6 +211,24 @@ TEST(PolymorphicTest, MoveFromValueless) {
   EXPECT_TRUE(b.valueless_after_move());
 }
 
+TEST(PolymorphicTest, AllocatorExtendedCopyFromValueless) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::polymorphic<Base> b(std::allocator_arg, a.get_allocator(), a);
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(PolymorphicTest, AllocatorExtendedMoveFromValueless) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::polymorphic<Base> b(std::allocator_arg, a.get_allocator(), std::move(a));
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
 TEST(PolymorphicTest, AssignFromValueless) {
   xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
   xyz::polymorphic<Base> aa(std::move(a));

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -239,7 +239,8 @@ TEST(PolymorphicTest, SwapFromValueless) {
   xyz::polymorphic<Base> b(xyz::in_place_type_t<Derived>{}, 101);
   EXPECT_TRUE(!b.valueless_after_move());
 
-  std::swap(a, b);
+  using std::swap;
+  swap(a, b);
   EXPECT_TRUE(!a.valueless_after_move());
   EXPECT_TRUE(b.valueless_after_move());
 }

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -101,6 +101,21 @@ TEST(PolymorphicTest, MoveRendersSourceValueless) {
   EXPECT_TRUE(a.valueless_after_move());
 }
 
+TEST(PolymorphicTest, AllocatorExtendedCopy) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::allocator_arg, a.get_allocator(), a);
+  EXPECT_EQ(a->value(), aa->value());
+  EXPECT_NE(&*a, &*aa);
+}
+
+TEST(PolymorphicTest, AllocatorExtendedMove) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::allocator_arg, a.get_allocator(),
+                            std::move(a));
+  EXPECT_EQ(aa->value(), 42);
+  EXPECT_TRUE(a.valueless_after_move());
+}
+
 TEST(PolymorphicTest, Swap) {
   xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
   xyz::polymorphic<Base> b(xyz::in_place_type_t<Derived>{}, 101);

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -193,6 +193,56 @@ TEST(PolymorphicTest, MemberSwapWithSelf) {
   EXPECT_FALSE(a.valueless_after_move());
 }
 
+TEST(PolymorphicTest, CopyFromValueless) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::polymorphic<Base> b(a);
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(PolymorphicTest, MoveFromValueless) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::polymorphic<Base> b(std::move(a));
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(PolymorphicTest, AssignFromValueless) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::polymorphic<Base> b = a;
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(PolymorphicTest, MoveAssignFromValueless) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::polymorphic<Base> b(xyz::in_place_type_t<Derived>{}, 101);
+  b = std::move(a);
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(PolymorphicTest, SwapFromValueless) {
+  xyz::polymorphic<Base> a(xyz::in_place_type_t<Derived>{}, 42);
+  xyz::polymorphic<Base> aa(std::move(a));
+
+  EXPECT_TRUE(a.valueless_after_move());
+  xyz::polymorphic<Base> b(xyz::in_place_type_t<Derived>{}, 101);
+  EXPECT_TRUE(!b.valueless_after_move());
+
+  std::swap(a, b);
+  EXPECT_TRUE(!a.valueless_after_move());
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
 TEST(PolymorphicTest, ConstPropagation) {
   struct SomeType {
     enum class Constness { CONST, NON_CONST };

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -216,7 +216,8 @@ TEST(PolymorphicTest, AssignFromValueless) {
   xyz::polymorphic<Base> aa(std::move(a));
 
   EXPECT_TRUE(a.valueless_after_move());
-  xyz::polymorphic<Base> b = a;
+  xyz::polymorphic<Base> b(xyz::in_place_type_t<Derived>{}, 101);
+  b = a;
   EXPECT_TRUE(b.valueless_after_move());
 }
 

--- a/presentations/vocabulary_types_2023_11_8.md
+++ b/presentations/vocabulary_types_2023_11_8.md
@@ -41,7 +41,8 @@ These fill a gap in the suite of existing standard library vocabulary types.
 # Vocabulary Types
 
 We refer to standard library types such as `std::array`, `std::map`,
-`std::optional`,  `std::variant` and `std::vector` as _vocabulary types_.
+`std::optional`,  `std::variant`, `std::tuple` and `std::vector` as
+_vocabulary types_.
 
 We postulate that an arbitrary piece of C++ library or application code would
 make use of some of these types.
@@ -71,6 +72,7 @@ Vocabulary types can be used to express common idioms.
 | An instance of an object `T` | `T` |
 | A nullable instance of an object `T` | `std::optional<T>` |
 | An instance of one of a closed-set of types `Ts...`| `std::variant<Ts...>`|
+| Once instance of each of a closed-set of types `Ts...`| `std::tuple<Ts...>`|
 | `N` instances of a type `T`| `std::array<T, N>`|
 | Variable-count, multiple instances of a type `T`| `std::vector<T>`|
 | Unique, variable-count, instances of a type `T`| `std::set<T>`|
@@ -89,7 +91,6 @@ can be compiler-generated if it is supported by all component objects.
 | Destructor | `~T();` |
 | Copy constructor/assignment | `T(const T&);` `T& operator=(const T&);` |
 | Move constructor/assignment|  `T(T&&);` `T& operator=(T&&);` |
-
 ---
 
 # Const propagation


### PR DESCRIPTION
Copy, move and swap of a valueless object should be permitted to be consistent with variant's handling of its own valueless state.