### PR TITLE
Ensure Visual Studio correctly declares the __cplusplus macro

### DIFF
--- a/cmake/xyz_add_test.cmake
+++ b/cmake/xyz_add_test.cmake
@@ -90,6 +90,11 @@ function(xyz_add_test)
         CXX_EXTENSIONS NO
     )
 
+    target_compile_options(${XYZ_NAME}
+        PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/Zc:__cplusplus>
+    )
+
     if(${XYZ_MANUAL})
         message(STATUS "Manual test: ${XYZ_NAME}")
     else()


### PR DESCRIPTION
So it turn out that Visual Studio has been incorrectly defining the `__cplusplus` macro all along, and so checks which depend on this, just as memory resource tests, are incorrectly not executed on Windows.

This is described at the following:
- https://stackoverflow.com/a/56483887/4764531
- https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/

The compiler option `/Zc:__cplusplus` ensures Visual Studio update the value of this macro.