### PR TITLE
No need to rebind allocators

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -491,11 +491,8 @@ value may only become valueless after it has been moved from.
 object of type `indirect<T, Allocator>` uses an object of type `Allocator` to
 allocate and free storage for the owned object as needed. The owned object is
 constructed using the function
- `allocator_traits<allocator_type>::rebind_traits<U>::construct` and destroyed
-using the function
-`allocator_traits<allocator_type>::rebind_traits<U>::destroy`, where `U` is
-either `allocator_type::value_type` or an internal type used by the indirect
-value.
+`allocator_traits<allocator_type>::construct` and destroyed
+using the function `allocator_traits<allocator_type>::destroy`.
 
 
 // DRAFTING NOTE: [indirect.general]#3 modeled on [container.reqmts]#64


### PR DESCRIPTION
There is no reason to mention internal types here. That's needed for node-based containers like `std::set<T>` and `std::map<T>` where we allocate nodes of internal types, and construct a `T`. For those containers we need two different allocator types, so the container stores one allocator type and rebinds to get the other allocator type. That's not relevant for your types, you have no internal node types. You allocate a `T` and construct a `T`, so the `indirect<T>` can just store an `Allocator` and use that directly to both allocate/deallocate and construct/destroy.