### PR TITLE
Commit empty MODULE.bazel file and ignore lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bazel-*
 build*/
 out/
 .cache
+MODULE.bazel.lock

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,6 @@
+###############################################################################
+# Bazel now uses Bzlmod by default to manage external dependencies.
+# Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel.
+#
+# For more details, please check https://github.com/bazelbuild/bazel/issues/18958
+###############################################################################


### PR DESCRIPTION
This is a short-term workaround until we upgrade our bazel setup to use MODULES.