### PR TITLE
Fix issues using "polymorphic_cxx14.h" in C++17 and later

### DIFF
--- a/polymorphic_cxx14.h
+++ b/polymorphic_cxx14.h
@@ -29,13 +29,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef XYZ_IN_PLACE_TYPE_DEFINED
 #define XYZ_IN_PLACE_TYPE_DEFINED
 namespace xyz {
-
 template <class T>
 struct in_place_type_t {};
+}  // namespace xyz
 #endif  // XYZ_IN_PLACE_TYPE_DEFINED
 
 #ifndef XYZ_UNREACHABLE_DEFINED
 #define XYZ_UNREACHABLE_DEFINED
+namespace xyz {
 [[noreturn]] inline void unreachable() {  // LCOV_EXCL_LINE
 #if (__cpp_lib_unreachable >= 202202L)
   std::unreachable();  // LCOV_EXCL_LINE
@@ -45,6 +46,7 @@ struct in_place_type_t {};
   __builtin_unreachable();  // LCOV_EXCL_LINE
 #endif
 }
+}  // namespace xyz
 #endif  // XYZ_UNREACHABLE_DEFINED
 
 #ifndef XYZ_EMPTY_BASE_DEFINED
@@ -55,6 +57,7 @@ struct in_place_type_t {};
 // We duplicate implementations to allow this header to work as a single
 // include. https://godbolt.org needs single-file includes.
 // TODO: Add tests to keep implementations in sync.
+namespace xyz {
 namespace detail {
 template <class T, bool CanBeEmptyBaseClass =
                        std::is_empty<T>::value && !std::is_final<T>::value>
@@ -78,8 +81,10 @@ class empty_base_optimization<T, true> : private T {
   const T& get() const noexcept { return *this; }
 };
 }  // namespace detail
+}  // namespace xyz
 #endif  // XYZ_EMPTY_BASE_DEFINED
 
+namespace xyz {
 namespace detail {
 template <class T, class A>
 struct control_block {

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -42,7 +42,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "feature_check.h"
 #include "tracking_allocator.h"
-#ifdef XYZ_HAS_STD_IN_PLACE_TYPE_T
+#if defined(XYZ_HAS_STD_IN_PLACE_TYPE_T) && !defined(XYZ_POLYMORPHIC_CXX_14)
 namespace xyz {
 using std::in_place_type_t;
 }  // namespace xyz


### PR DESCRIPTION
The non-C++14 `polymorphic` requires C++20.
If the C++14 `polymorphic` is being used in C++17 mode, then both `xyz::in_place_type_t` and `std::in_place_type_t` will exist. Make sure they have the same definition in all places. This fixes a compilation error when compiling "polymorphic_test.h" with `-std=c++17 -DXYZ_POLYMORPHIC_CXX_14`.

Also, match the open/close of `namespace xyz` with the open/close of preprocessor conditionals, so that you don't get a compilation error when compiling "indirect.h" followed by "polymorphic_cxx14.h" in `-std=c++20` mode.