### PR TITLE
[do not merge] Implement P1144 trivially-relocatable for `indirect` and `polymorphic`

### DIFF
--- a/indirect.h
+++ b/indirect.h
@@ -49,7 +49,8 @@ namespace xyz {
 
 #ifndef XYZ_TRIVIALLY_RELOCATABLE_IF_DEFINED
 #define XYZ_TRIVIALLY_RELOCATABLE_IF_DEFINED
-#if defined(__cpp_impl_trivially_relocatable) && defined(__cpp_lib_trivially_relocatable)
+#if defined(__cpp_impl_trivially_relocatable) && \
+    defined(__cpp_lib_trivially_relocatable)
 #define XYZ_TRIVIALLY_RELOCATABLE_IF(x) [[trivially_relocatable(x)]]
 #else
 #define XYZ_TRIVIALLY_RELOCATABLE_IF(x)
@@ -76,12 +77,14 @@ inline constexpr bool indirect_allocator_pocma_models_relocatable_v =
 template <class A>
 inline constexpr bool indirect_be_trivially_relocatable_v =
     std::is_trivially_relocatable_v<A> &&
-    std::is_trivially_relocatable_v<typename std::allocator_traits<A>::pointer> &&
+    std::is_trivially_relocatable_v<
+        typename std::allocator_traits<A>::pointer> &&
     indirect_allocator_pocma_models_relocatable_v<A>;
 #endif
 
 template <class T, class A = std::allocator<T>>
-class XYZ_TRIVIALLY_RELOCATABLE_IF(indirect_be_trivially_relocatable_v<A>) indirect {
+class XYZ_TRIVIALLY_RELOCATABLE_IF(
+    indirect_be_trivially_relocatable_v<A>) indirect {
   using allocator_traits = std::allocator_traits<A>;
 
  public:

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -49,7 +49,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 namespace {
 
 TEST(IndirectTest, TriviallyRelocatable) {
-#if defined(__cpp_impl_trivially_relocatable) && defined(__cpp_lib_trivially_relocatable)
+#if defined(__cpp_impl_trivially_relocatable) && \
+    defined(__cpp_lib_trivially_relocatable)
   static_assert(std::is_trivially_relocatable_v<xyz::indirect<int>>);
 #ifdef XYZ_HAS_STD_MEMORY_RESOURCE
   static_assert(!std::is_trivially_relocatable_v<

--- a/indirect_test.cc
+++ b/indirect_test.cc
@@ -41,11 +41,22 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifdef XYZ_HAS_STD_OPTIONAL
 #include <optional>
 #endif  // XYZ_HAS_STD_OPTIONAL
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace {
+
+TEST(IndirectTest, TriviallyRelocatable) {
+#if defined(__cpp_impl_trivially_relocatable) && defined(__cpp_lib_trivially_relocatable)
+  static_assert(std::is_trivially_relocatable_v<xyz::indirect<int>>);
+#ifdef XYZ_HAS_STD_MEMORY_RESOURCE
+  static_assert(!std::is_trivially_relocatable_v<
+                xyz::indirect<int, std::pmr::polymorphic_allocator<int>>>);
+#endif
+#endif  // defined(__cpp_impl_trivially_relocatable) && ...
+}
 
 TEST(IndirectTest, ValueAccessFromInPlaceConstructedObject) {
   xyz::indirect<int> a(42);

--- a/polymorphic.h
+++ b/polymorphic.h
@@ -43,7 +43,8 @@ namespace xyz {
 
 #ifndef XYZ_TRIVIALLY_RELOCATABLE_IF_DEFINED
 #define XYZ_TRIVIALLY_RELOCATABLE_IF_DEFINED
-#if defined(__cpp_impl_trivially_relocatable) && defined(__cpp_lib_trivially_relocatable)
+#if defined(__cpp_impl_trivially_relocatable) && \
+    defined(__cpp_lib_trivially_relocatable)
 #define XYZ_TRIVIALLY_RELOCATABLE_IF(x) [[trivially_relocatable(x)]]
 #else
 #define XYZ_TRIVIALLY_RELOCATABLE_IF(x)
@@ -133,7 +134,8 @@ inline constexpr bool polymorphic_be_trivially_relocatable_v =
 #endif
 
 template <class T, class A = std::allocator<T>>
-class XYZ_TRIVIALLY_RELOCATABLE_IF((polymorphic_be_trivially_relocatable_v<T, A>)) polymorphic {
+class XYZ_TRIVIALLY_RELOCATABLE_IF(
+    (polymorphic_be_trivially_relocatable_v<T, A>)) polymorphic {
   using cblock_t = detail::control_block<T, A>;
   cblock_t* cb_;
 

--- a/polymorphic_cxx14.h
+++ b/polymorphic_cxx14.h
@@ -51,7 +51,8 @@ namespace xyz {
 
 #ifndef XYZ_TRIVIALLY_RELOCATABLE_IF_DEFINED
 #define XYZ_TRIVIALLY_RELOCATABLE_IF_DEFINED
-#if defined(__cpp_impl_trivially_relocatable) && defined(__cpp_lib_trivially_relocatable)
+#if defined(__cpp_impl_trivially_relocatable) && \
+    defined(__cpp_lib_trivially_relocatable)
 #define XYZ_TRIVIALLY_RELOCATABLE_IF(x) [[trivially_relocatable(x)]]
 #else
 #define XYZ_TRIVIALLY_RELOCATABLE_IF(x)
@@ -163,23 +164,31 @@ class direct_control_block final : public control_block<T, A> {
 
 #if defined(__cpp_lib_trivially_relocatable)
 template <class A>
-struct polymorphic_allocator_pocma_models_relocatable : std::integral_constant<bool,
-    std::allocator_traits<A>::is_always_equal::value ||
-    (std::allocator_traits<A>::propagate_on_container_copy_assignment::value &&
-     std::allocator_traits<A>::propagate_on_container_move_assignment::value &&
-     std::allocator_traits<A>::propagate_on_container_swap::value)
-> {};
+struct polymorphic_allocator_pocma_models_relocatable
+    : std::integral_constant<
+          bool,
+          std::allocator_traits<A>::is_always_equal::value ||
+              (std::allocator_traits<
+                   A>::propagate_on_container_copy_assignment::value &&
+               std::allocator_traits<
+                   A>::propagate_on_container_move_assignment::value &&
+               std::allocator_traits<A>::propagate_on_container_swap::value)> {
+};
 
 template <class T, class A>
-struct polymorphic_be_trivially_relocatable : std::integral_constant<bool,
-    std::is_trivially_relocatable<A>::value &&
-    std::is_trivially_relocatable<detail::control_block<T, A>*>::value &&
-    polymorphic_allocator_pocma_models_relocatable<A>::value
-> {};
+struct polymorphic_be_trivially_relocatable
+    : std::integral_constant<
+          bool, std::is_trivially_relocatable<A>::value &&
+                    std::is_trivially_relocatable<
+                        detail::control_block<T, A>*>::value &&
+                    polymorphic_allocator_pocma_models_relocatable<A>::value> {
+};
 #endif
 
 template <class T, class A = std::allocator<T>>
-class XYZ_TRIVIALLY_RELOCATABLE_IF((polymorphic_be_trivially_relocatable<T, A>::value)) polymorphic : private detail::empty_base_optimization<A> {
+class XYZ_TRIVIALLY_RELOCATABLE_IF(
+    (polymorphic_be_trivially_relocatable<T, A>::value)) polymorphic
+    : private detail::empty_base_optimization<A> {
   using cblock_t = detail::control_block<T, A>;
   cblock_t* cb_;
 

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -56,6 +56,7 @@ using std::in_place_type_t;
 #ifdef XYZ_HAS_STD_OPTIONAL
 #include <optional>
 #endif  // XYZ_HAS_STD_OPTIONAL
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -151,6 +152,16 @@ TEST(PolymorphicTest, SwapWithNoSBOAndSBO) {
   swap(a, b);
   EXPECT_EQ(a->value(), 101);
   EXPECT_EQ(b->value(), 42);
+}
+
+TEST(PolymorphicTest, TriviallyRelocatable) {
+#if defined(__cpp_impl_trivially_relocatable) && defined(__cpp_lib_trivially_relocatable)
+  static_assert(std::is_trivially_relocatable<xyz::polymorphic<int>>::value, "");
+#ifdef XYZ_HAS_STD_MEMORY_RESOURCE
+  static_assert(!std::is_trivially_relocatable_v<
+                xyz::polymorphic<int, std::pmr::polymorphic_allocator<int>>>);
+#endif
+#endif  // defined(__cpp_impl_trivially_relocatable) && ...
 }
 
 TEST(PolymorphicTest, AccessDerivedObject) {

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -155,8 +155,10 @@ TEST(PolymorphicTest, SwapWithNoSBOAndSBO) {
 }
 
 TEST(PolymorphicTest, TriviallyRelocatable) {
-#if defined(__cpp_impl_trivially_relocatable) && defined(__cpp_lib_trivially_relocatable)
-  static_assert(std::is_trivially_relocatable<xyz::polymorphic<int>>::value, "");
+#if defined(__cpp_impl_trivially_relocatable) && \
+    defined(__cpp_lib_trivially_relocatable)
+  static_assert(std::is_trivially_relocatable<xyz::polymorphic<int>>::value,
+                "");
 #ifdef XYZ_HAS_STD_MEMORY_RESOURCE
   static_assert(!std::is_trivially_relocatable_v<
                 xyz::polymorphic<int, std::pmr::polymorphic_allocator<int>>>);


### PR DESCRIPTION
This is my take on #302, just to have a "clean copy." I would _like_ it merged, but I _expect_ it to be closed, per the discussion on #302 about not wanting to maintain the extra complexity. (My goal is just to record this branch history in a neat place for any posterity who want to [play with it on Godbolt.](https://godbolt.org/z/rPoK4PT4b))

I've added the same logic for `polymorphic<T>`. (#302 did it only for `indirect<T>`.)
While doing this, I noticed:
- Neither type has any unit tests for `is_nothrow_move_constructible`, `!is_trivially_fooable`, etc. I think such unit tests should be added.
- `indirect<T>` correctly uses `allocator_traits<A>::pointer`, but `polymorphic<T>` hard-codes `cblock_t*` instead of `allocator_traits<A>::rebind_alloc<cblock_t>::pointer`. This means `polymorphic<T>` isn't compatible with Boost.Interprocess `offset_ptr` allocators. I could work up such a PR if you're interested; but (next bullet)
- I'm not sure I understand all the various versions of polymorphic that seem to exist side-by-side right now.
- I see a lot of uses of `XYZ_HAS_STD_OPTIONAL` (invariably true in C++17 and later) in "indirect_test.cc" (requires C++20 or later); these could perhaps be removed, unless the plan is to backport `indirect` to C++14-or-earlier just like `polymorphic` was backported.