### PR TITLE
Amend wording after discussion with Jonathan Wakely

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,35 +3,49 @@
 ## Using pre-commit for git hooks
 
 This repository uses the Python `pre-commit` library to manage git hook run as
-part of the commit process.  Use the following steps to install a virtual
-environment with pre-commmit set up, and then use precommit to install git hooks
-it to your local repository.
+part of the commit process.  Use the following steps from the project root to
+install a virtual environment with pre-commmit set up, and then use precommit to
+install git hooks it to your local repository:
 
 ```bash
-cd <project root>
 python3 -m venv .venv           # Create a Python virtual env
 source ./.venv/bin/activate     # Activate the virtual env for bash by source.
 pip install -r requirements.txt # Install latest requirements including pre-commit
 pre-commit install              # Use pre-commit to install git hooks into the working repository.
 ```
 
-## Building with CMake
+## Building and testing
 
-To build the repository with CMake use the following steps
+### Building with CMake
+
+To build the repository with CMake use the following steps from the project root:
+
 ```bash
-cd <project root>
-mkdir build          # Make a build directory
-cd build             # Switch into the build directory
-cmake ../            # Generate build system specified in root with cmake
-cmake --build ./     # Build the underlying build system via CMake
+mkdir build             # Make a build directory
+cmake -Bbuild           # Generate build system specified in build directory with cmake
+cmake --build build     # Build the underlying build system via CMake
+ctest --test-dir build  # Run the tests
 ```
+
+To install CMake see: https://cmake.org/download/.
+
+### Building with Bazel
+
+To build the repository with Bazel use the following steps from the project root:
+
+```bash
+bazel build //...       # Build the project
+bazel test //...        # Run the tests
+```
+
+To install Bazel see https://bazel.build/install.
 
 ## Including value_types to your own project
 
 To use the value types code in your own CMake project then you can pull
 the project in as a dependency via CMake's FetchContent module as follows:
 
-```
+```txt
 FetchContent_Declare(
     value_types
     GIT_REPOSITORY https://github.com/jbcoe/value_types

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -591,13 +591,15 @@ become valueless after it has been moved from.
 `allocator_traits<Allocator>::value_type` is not the same type as `T`, the
 program is ill-formed. Every object of type `indirect<T, Allocator>` uses an
 object of type `Allocator` to allocate and free storage for the owned object as
-needed. The owned object is constructed using the function
-`allocator_traits<allocator_type>::construct` and destroyed using the function
-`allocator_traits<allocator_type>::destroy`.
+needed.
+
+3. Constructing an owned object using an allocator `a` and arguments `args...`
+means calling `allocator_traits<allocator_type>::construct(a, p, args...)` where
+`p` is a pointer to suitable storage.
 
 // DRAFTING NOTE: [indirect.general]#3 modeled on [container.reqmts]#64
 
-3. Copy constructors for an indirect value obtain an allocator by calling
+4. Copy constructors for an indirect value obtain an allocator by calling
 `allocator_traits<allocator_type>::select_on_container_copy_construction` on the
 allocator belonging to the indirect value being copied. Move constructors obtain
 an allocator by move construction from the allocator belonging to the object
@@ -622,15 +624,15 @@ move assignment, or swapping of the allocator only if
     is `true` within the implementation of the corresponding indirect value
     operation.
 
-4. A program that instantiates the definition of indirect for a non-object type,
+5. A program that instantiates the definition of indirect for a non-object type,
    an array type, or a cv-qualified type is ill-formed.
 
-5. The template parameter `T` of `indirect` may be an incomplete type.
+6. The template parameter `T` of `indirect` may be an incomplete type.
 
-6. The template parameter `Allocator` of `indirect` shall meet the
+7. The template parameter `Allocator` of `indirect` shall meet the
    _Cpp17Allocator_ requirements.
 
-7. If a program declares an explicit or partial specialization of `indirect`,
+8. If a program declares an explicit or partial specialization of `indirect`,
    the behavior is undefined.
 
 #### X.Y.2 Class template indirect synopsis [indirect.syn]
@@ -1102,14 +1104,15 @@ object may only become valueless after it has been moved from.
 `allocator_traits<Allocator>::value_type` is not the same type as`T`, the
 program is ill-formed. Every object of type `polymorphic<T, Allocator>` uses an
 object of type `Allocator` to allocate and free storage for the owned object as
-needed. The owned object is constructed using the function
-`allocator_traits<allocator_type>::rebind_traits<U>::construct` and destroyed
- using the function
-`allocator_traits<allocator_type>::rebind_traits<U>::destroy`, where `U` is
+needed.
+
+3. Constructing an owned object using an allocator `a` and arguments
+`args...` means calling `allocator_traits<allocator_type>::rebind_traits<U>::construct(a, p,
+args...)` where `p` is a pointer to suitable storage and `U` is
 either `allocator_type::value_type` or an internal type used by the polymorphic
 value.
 
-3. Copy constructors for a polymorphic value obtain an allocator by calling
+4. Copy constructors for a polymorphic value obtain an allocator by calling
 `allocator_traits<allocator_type>::select_on_container_copy_construction` on the
 allocator belonging to the polymorphic value being copied. Move constructors
 obtain an allocator by move construction from the allocator belonging to the
@@ -1129,15 +1132,15 @@ or (64.3) `allocator_traits<allocator_type>::propagate_on_container_swap::value`
 is true within the implementation of the corresponding polymorphic value
 operation.
 
-4. A program that instantiates the definition of polymorphic for a non-object
+5. A program that instantiates the definition of polymorphic for a non-object
    type, an array type, or a cv-qualified type is ill-formed.
 
-5. The template parameter `T` of `polymorphic` may be an incomplete type.
+6. The template parameter `T` of `polymorphic` may be an incomplete type.
 
-6. The template parameter `Allocator` of `polymorphic` shall meet the
+7. The template parameter `Allocator` of `polymorphic` shall meet the
    requirements of _Cpp17Allocator_.
 
-7. If a program declares an explicit or partial specialization of `polymorphic`,
+8. If a program declares an explicit or partial specialization of `polymorphic`,
    the behavior is undefined.
 
 #### X.Z.2 Class template polymorphic synopsis [polymorphic.syn]

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -44,6 +44,12 @@ should not be considered in isolation.
 
 ### Changes in R7
 
+* Add more explicit wording for use of `allocator_traits::construct` in
+  `indirect` and `polymorphic` constructors.
+
+* Discuss `indirects` non-conditional copy constructior in the light of
+  implementation tricks that would enable it.
+
 * Improve wording for assignment operators to remove ambiguity.
 
 * Add motivation for `valueless_after_move` member function.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1108,8 +1108,8 @@ needed.
 
 3. Constructing an owned object using an allocator `a` and arguments `args...`
 means calling `allocator_traits<allocator_type>::rebind_traits<U>::construct(a,
-p, args...)` where `p is a pointer obtained by calling
-allocator_traits<allocator_type>::rebind_traits<U>::allocate` and `U` is either
+p, args...)` where `p` is a pointer obtained by calling
+`allocator_traits<allocator_type>::rebind_traits<U>::allocate` and `U` is either
 `allocator_type::value_type` or an internal type used by the polymorphic value.
 
 4. Copy constructors for a polymorphic value obtain an allocator by calling

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -873,7 +873,7 @@ constexpr indirect& operator=(const indirect& other);
   object is assigned to `*other`.
 
   Otherwise, if `alloc != other.alloc` or `this` is valueless, a new owned
-  object is constructed in `this` using
+  object is constructed in `*this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
   `other` as the argument, using either the allocator in `this` or the allocator
   in `other` if the allocator needs updating. The previously owned object in

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -906,7 +906,7 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   `*this`, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
   and then the storage is deallocated.
 
-  Otherwise, if `alloc == other.alloc`, swaps the owned objects in `this` and
+  Otherwise, if `alloc == other.alloc`, swaps the owned objects in `*this` and
   `other`; the owned object in `other`, if any, is then destroyed using
   `allocator_traits<allocator_type>::destroy` and then the storage is deallocated.
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -987,7 +987,7 @@ constexpr allocator_type get_allocator() const noexcept;
 ```c++
 constexpr void swap(indirect& other) noexcept(
   allocator_traits::propagate_on_container_swap::value
-  || allocator_traits::is_always_equal::value);
+  || allocator_traits<Allocator>::is_always_equal::value);
 ```
 
 1. _Effects_: Swaps the states of `*this` and `other`, exchanging owned objects

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1387,7 +1387,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
   storage is deallocated.
 
   Otherwise, if `alloc != other.alloc`; if `other` is not valueless, a new owned
-  object is constructed in `this` using
+  object is constructed in `*this` using
   `allocator_traits<allocator_type>::rebind_traits::construct` with the owned
   object from `other` as the argument as an rvalue, using either the allocator
   in `*this` or the allocator in `other` if the allocator needs updating. The

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -866,7 +866,7 @@ constexpr indirect& operator=(const indirect& other);
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
   If `other` is valueless, `*this` becomes valueless and the owned object in
-  this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
+  `*this`, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
   and then the storage is deallocated.
 
   Otherwise, if `alloc == other.alloc` and `this` is not valueless, the owned

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -917,7 +917,7 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   the allocator in `other` if the allocator needs updating. The previous owned
   object in `*this`, if any, is destroyed using
   `allocator_traits<allocator_type>::destroy` and then the storage is
-  deallocated. If the allocator needs updating, the allocator in `this` is
+  deallocated. If the allocator needs updating, the allocator in `*this` is
   replaced with a copy of the allocator in `other`.
 
 6. _Postconditions_: `other` is valueless.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -751,7 +751,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a);
 7. _Mandates_: `T` is a complete type.
 
 8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs owned
-   object of type `T` with no arguments.
+   object of type `T` with an empty argument list.
 
 9. _Postconditions_: `*this` is not valueless.
 
@@ -1227,7 +1227,7 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a);
 7. _Mandates_: `T` is a complete type.
 
 8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
-   owned object of type `T` with no arguments.
+   owned object of type `T` with an empty argument list.
 
 9. _Postconditions_: `*this` is not valueless.
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1390,7 +1390,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
   object is constructed in `this` using
   `allocator_traits<allocator_type>::rebind_traits::construct` with the owned
   object from `other` as the argument as an rvalue, using either the allocator
-  in `this` or the allocator in `other` if the allocator needs updating. The
+  in `*this` or the allocator in `other` if the allocator needs updating. The
   previous owned object in `*this`, if any, is destroyed using
   `allocator_traits<allocator_type>::rebind_traits::destroy` and then the
   storage is deallocated.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -877,7 +877,7 @@ constexpr indirect& operator=(const indirect& other);
   `allocator_traits<allocator_type>::construct` with the owned object from
   `other` as the argument, using either the allocator in `this` or the allocator
   in `other` if the allocator needs updating. The previously owned object in
-  this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
+  `*this`, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
   and then the storage is deallocated.
 
   If the allocator needs updating, the allocator in `this` is replaced with a

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -49,7 +49,7 @@ should not be considered in isolation.
 
 ### Changes in R7
 
-* Discuss `indirects` non-conditional copy constructior in the light of
+* Discuss `indirect`'s non-conditional copy constructor in the light of
   implementation tricks that would enable it.
 
 * Improve wording for assignment operators to remove ambiguity.
@@ -601,7 +601,7 @@ program is ill-formed. Every object of type `indirect<T, Allocator>` uses an
 object of type `Allocator` to allocate and free storage for the owned object as
 needed.
 
-3. Constructing an owned object using an allocator `a` and arguments `args...`
+3. Constructing an owned object with arguments `args...` using an allocator `a`
 means calling `allocator_traits<allocator_type>::construct(a, p, args...)` where
 `p` is a pointer obtained by calling
 `allocator_traits<allocator_type>::allocate`.
@@ -759,7 +759,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a);
 
 7. _Mandates_: `T` is a complete type.
 
-8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs owned
+8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an owned
    object of type `T` with an empty argument list, using the allocator `alloc`.
 
 9. _Postconditions_: `*this` is not valueless.
@@ -830,7 +830,7 @@ constexpr indirect(allocator_arg_t, const Allocator& a, indirect&& other)
 
 22. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other` is
     valueless, `*this` is valueless. Otherwise, if `alloc == other.alloc`
-    constructs an object of type `indirect` that owns the owned value of other;
+    constructs an object of type `indirect` that owns the owned object of other;
     `other` is valueless. Otherwise constructs an owned object of type `T` with
     `*std::move(other)`, using the allocator `alloc`.
 
@@ -846,8 +846,8 @@ constexpr ~indirect();
 1. _Mandates_: `T` is a complete type.
 
 2. _Effects_: If `*this` is not valueless, destroys the owned object using
-  `allocator_traits<allocator_type>::destroy` and then deallocates the storage
-  using `allocator_traits<allocator_type>::deallocate`.
+  `allocator_traits<allocator_type>::destroy` and then the storage is
+  deallocated.
 
 #### X.Y.5 Assignment [indirect.assign]
 
@@ -862,9 +862,9 @@ constexpr indirect& operator=(const indirect& other);
   If `std::allocator_traits<Alloc>::propagate_on_container_copy_assignment` is
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
-  If `other` is valueless, `*this` becomes valueless and the owned value in
+  If `other` is valueless, `*this` becomes valueless and the owned object in
   this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
-  and then deallocated using `allocator_traits<allocator_type>::deallocate`.
+  and then the storage is deallocated.
 
   Otherwise, if `alloc == other.alloc` and `this` is not valueless, the owned
   object is assigned to `*other`.
@@ -875,7 +875,7 @@ constexpr indirect& operator=(const indirect& other);
   `other` as the argument, using either the allocator in `this` or the allocator
   in `other` if the allocator needs updating. The previously owned object in
   this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
-  and then deallocated using `allocator_traits<allocator_type>::deallocate`.
+  and then the storage is deallocated.
 
   If the allocator needs updating, the allocator in `this` is replaced with a
   copy of the allocator in `other`.
@@ -899,26 +899,23 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   `std::allocator_traits<Alloc>::propagate_on_container_move_assignment` is
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
-  If `other` is valueless, `*this` becomes valueless and the owned value in
+  If `other` is valueless, `*this` becomes valueless and the owned object in
   this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
-  and then deallocated using `allocator_traits<allocator_type>::deallocate`.
+  and then the storage is deallocated.
 
   Otherwise if `alloc == other.alloc`, swaps the owned objects in `this` and
   `other`; the owned object in `other`, if any, is then destroyed using
-  `allocator_traits<allocator_type>::destroy` and then deallocated using
-  `allocator_traits<allocator_type>::deallocate`.
+  `allocator_traits<allocator_type>::destroy` and then the storage is deallocated.
 
   Otherwise , if `alloc != other.alloc` or `this` is valueless, a new owned
   object is constructed in `this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
   `other` as the argument as an rvalue, using either the allocator in `this` or
   the allocator in `other` if the allocator needs updating. The previous owned
-  object in this, if any, is destroyed using
-  `allocator_traits<allocator_type>::destroy` and then deallocated using
-  `allocator_traits<allocator_type>::deallocate`.
-
-  If the allocator needs updating, the allocator in `this` is replaced with a
-  copy of the allocator in `other`.
+  object in `*this`, if any, is destroyed using
+  `allocator_traits<allocator_type>::destroy` and then the storage is
+  deallocated. If the allocator needs updating, the allocator in `this` is
+  replaced with a copy of the allocator in `other`.
 
 6. _Postconditions_: `other` is valueless.
 
@@ -1113,7 +1110,7 @@ program is ill-formed. Every object of type `polymorphic<T, Allocator>` uses an
 object of type `Allocator` to allocate and free storage for the owned object as
 needed.
 
-3. Constructing an owned object using an allocator `a` and arguments `args...`
+3. Constructing an owned object with arguments `args...` using an allocator `a`
 means calling `allocator_traits<allocator_type>::rebind_traits<U>::construct(a,
 p, args...)` where `p` is a pointer obtained by calling
 `allocator_traits<allocator_type>::rebind_traits<U>::allocate` and `U` is either
@@ -1312,11 +1309,11 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
 
 21. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other` is
     valueless, `*this` is valueless. Otherwise, if `alloc == other.alloc` either
-    constructs an object of type `polymorphic` that owns the owned value of
+    constructs an object of type `polymorphic` that owns the owned object of
     other, making `other` valueless; or, owns an object of the same type
-    constructed from the owned value of `other` considering that owned value as
+    constructed from the owned object of `other` considering that owned object as
     an rvalue. Otherwise if `alloc != other.alloc`, constructs an object of type
-    `polymorphic`, considering that owned value as an rvalue, using the
+    `polymorphic`, considering that owned object as an rvalue, using the
     allocator `alloc`.
 
   _[Drafting note: The above is intended to permit a small-buffer-optimization
@@ -1336,8 +1333,8 @@ constexpr ~polymorphic();
 1. _Mandates_: `T` is a complete type.
 
 2. _Effects_: If `*this` is not valueless, destroys the owned object using
-  `allocator_traits<allocator_type>::destroy` and then deallocates the storage
-  using `allocator_traits<allocator_type>::deallocate`.
+  `allocator_traits<allocator_type>::rebind_traits::destroy` and then the
+  storage is deallocated.
 
 #### X.Z.5 Assignment [polymorphic.assign]
 
@@ -1353,13 +1350,13 @@ constexpr polymorphic& operator=(const polymorphic& other);
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
   If `other` is not valueless, a new owned object is constructed in `this` using
-  `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument, using either the allocator in `this` or the allocator
-  in `other` if the allocator needs updating.
+  `allocator_traits<allocator_type>::rebind_traits::construct` with the owned
+  object from `other` as the argument, using either the allocator in `this` or
+  the allocator in `other` if the allocator needs updating.
 
-  The previous owned object in this, if any, is destroyed using
-  `allocator_traits<allocator_type>::destroy` and then deallocated using
-  `allocator_traits<allocator_type>::deallocate`.
+  The previous owned object in `*this`, if any, is destroyed using
+  `allocator_traits<allocator_type>::rebind_traits::destroy` and then the
+  storage is deallocated.
 
   If the allocator needs updating, the allocator in `this` is replaced with a
   copy of the allocator in `other`.
@@ -1383,17 +1380,17 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
 
   If `alloc == other.alloc`, swaps the owned objects in `this` and `other`; the
   owned object in `other`, if any, is then destroyed using
-  `allocator_traits<allocator_type>::destroy` and then deallocated using
-  `allocator_traits<allocator_type>::deallocate`.
+  `allocator_traits<allocator_type>::rebind_traits::destroy` and then the
+  storage is deallocated.
 
   Otherwise if `alloc != other.alloc`; if `other` is not valueless, a new owned
   object is constructed in `this` using
-  `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument as an rvalue, using either the allocator in `this` or
-  the allocator in `other` if the allocator needs updating. The previous owned
-  object in this, if any, is destroyed using
-  `allocator_traits<allocator_type>::destroy` and then deallocated using
-  `allocator_traits<allocator_type>::deallocate`.
+  `allocator_traits<allocator_type>::rebind_traits::construct` with the owned
+  object from `other` as the argument as an rvalue, using either the allocator
+  in `this` or the allocator in `other` if the allocator needs updating. The
+  previous owned object in `*this`, if any, is destroyed using
+  `allocator_traits<allocator_type>::rebind_traits::destroy` and then the
+  storage is deallocated.
 
   If the allocator needs updating, the allocator in `this` is replaced with a
   copy of the allocator in `other`.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1381,7 +1381,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
   If `allocator_traits<Alloc>::propagate_on_container_copy_assignment` is
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
-  If `alloc == other.alloc`, swaps the owned objects in `this` and `other`; the
+  If `alloc == other.alloc`, swaps the owned objects in `*this` and `other`; the
   owned object in `other`, if any, is then destroyed using
   `allocator_traits<allocator_type>::rebind_traits::destroy` and then the
   storage is deallocated.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1307,7 +1307,7 @@ constexpr polymorphic(polymorphic&& other) noexcept;
 
 ```c++
 constexpr polymorphic(allocator_arg_t, const Allocator& a,
-                      polymorphic&& other) noexcept(allocator_traits::is_always_equal::value);
+                      polymorphic&& other) noexcept(allocator_traits<Allocator>::is_always_equal::value);
 ```
 
 21. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other` is

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -42,10 +42,12 @@ should not be considered in isolation.
 
 ## History
 
-### Changes in R7
+### Changes in R8
 
 * Add more explicit wording for use of `allocator_traits::construct` in
   `indirect` and `polymorphic` constructors.
+
+### Changes in R7
 
 * Discuss `indirects` non-conditional copy constructior in the light of
   implementation tricks that would enable it.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -635,7 +635,7 @@ move assignment, or swapping of the allocator only if
     operation.
 
 4. A program that instantiates the definition of indirect for a non-object type,
-   an array type, in_place_t, or a cv-qualified type is ill-formed.
+   an array type, `in_place_t`, or a cv-qualified type is ill-formed.
 
 6. The template parameter `T` of `indirect` may be an incomplete type.
 
@@ -1140,7 +1140,7 @@ is true within the implementation of the corresponding polymorphic value
 operation.
 
 4. A program that instantiates the definition of polymorphic for a non-object
-   type, an array type, a specialization of in_place_type_t or a cv-qualified
+   type, an array type, a specialization of `in_place_type_t` or a cv-qualified
    type is ill-formed.
 
 6. The template parameter `T` of `polymorphic` may be an incomplete type.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -3,7 +3,7 @@
 
 ISO/IEC JTC1 SC22 WG21 Programming Language C++
 
-P3019R6
+P3019R7
 
 Working Group: Library Evolution, Library
 
@@ -752,7 +752,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a);
 7. _Mandates_: `T` is a complete type.
 
 8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Value
-   initializes an owned object of type `T` using the specified allocator.
+   initializes an owned object of type `T`.
 
 9. _Postconditions_: `*this` is not valueless.
 
@@ -784,8 +784,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a, in_place_t, Us&
 15. _Mandates_: `T` is a complete type.
 
 16. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Direct-non-list-initializes an owned object of type `T` using the specified
-    allocator with `std​::​forward<Us>(us...)`.
+    Direct-non-list-initializes an owned object of type `T` with `std​::​forward<Us>(us...)`.
 
 17. _Postconditions_: `*this` is not valueless.
 
@@ -806,7 +805,7 @@ constexpr indirect(allocator_arg_t, const Allocator& a,
 
 20. _Effects_: `alloc` is direct-non-list-initialized with `a`. If
     `other` is valueless, `*this` is valueless. Otherwise, copy constructs an
-    owned object of type `T` using the specified allocator with `*other`.
+    owned object of type `T` with `*other`.
 
 ```c++
 constexpr indirect(indirect&& other) noexcept;
@@ -823,8 +822,8 @@ constexpr indirect(allocator_arg_t, const Allocator& a, indirect&& other)
 22. _Effects_: `alloc` is direct-non-list-initialized with `a`. If
     `other` is valueless, `*this` is valueless. Otherwise, if `alloc ==
     other.alloc` constructs an object of type `indirect` that owns the owned
-    value of other; `other` is valueless. Otherwise constructs an object of type
-    `indirect` using the specified allocator with `*other` used as an rvalue.
+    value of other; `other` is valueless. Otherwise constructs an owned object of type
+    `T` with `*other` used as an rvalue.
 
 23. _[Note: The use of this function may require that `T` be a complete type
     dependent on behavour of the allocator. — end note]_
@@ -1230,7 +1229,7 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a);
 7. _Mandates_: `T` is a complete type.
 
 8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Value
-initializes an owned object of type `T` using the specified allocator.
+initializes an owned object of type `T`.
 
 9. _Postconditions_: `*this` is not valueless.
 
@@ -1263,8 +1262,7 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a,
 14. _Mandates_: `T` is a complete type.
 
 15. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Direct-non-list-initializes an owned object of type `U` using the specified
-    allocator with `std​::​forward<Ts>(ts...)`.
+    Direct-non-list-initializes an owned object of type `U` with `std​::​forward<Ts>(ts...)`.
 
 16. _Postconditions_: `*this` is not valueless.  The owned instance targets an
   object of type `U` constructed  with `std::forward<Ts>(ts)...`.
@@ -1287,7 +1285,7 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
 19. _Effects_: `alloc` is direct-non-list-initialized with `alloc`. If
     `other` is valueless, `*this` is valueless. Otherwise, copy constructs an
     owned object of type `U`, where `U` is the type of the owned object in
-    `other`, using the specified allocator with the owned object in `other`.
+    `other`, with the owned object in `other`.
 
 ```c++
 constexpr polymorphic(polymorphic&& other) noexcept;
@@ -1301,14 +1299,14 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
                       polymorphic&& other) noexcept(allocator_traits::is_always_equal::value);
 ```
 
-21. _Effects_: `alloc` is direct-non-list-initialized with `a`. If
-    `other` is valueless, `*this` is valueless. Otherwise, if `alloc ==
-    other.alloc` either constructs an object of type `polymorphic` that owns the
-    owned value of other, making `other` valueless; or, owns an object of the
-    same type constructed from the owned value of `other` using the specified
-    allocator, considering that owned value as an rvalue. Otherwise if `alloc !=
-    other.alloc`, constructs an object of type `polymorphic` using the specified
-    allocator, considering that owned value as an rvalue.
+21. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other` is
+    valueless, `*this` is valueless. Otherwise, if `alloc == other.alloc` either
+    constructs an object of type `polymorphic` that owns the owned value of
+    other, making `other` valueless; or, owns an object of the same type
+    constructed from the owned value of `other` using the specified allocator,
+    considering that owned value as an rvalue. Otherwise if `alloc !=
+    other.alloc`, constructs an object of type `polymorphic`, considering that
+    owned value as an rvalue.
 
   _[Drafting note: The above is intended to permit a small-buffer-optimization
   and handle the case where allocators compare equal but we do not want to swap

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -750,8 +750,8 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a);
 
 7. _Mandates_: `T` is a complete type.
 
-8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Value
-   initializes an owned object of type `T`.
+8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs owned
+   object of type `T` with no arguments.
 
 9. _Postconditions_: `*this` is not valueless.
 
@@ -783,7 +783,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a, in_place_t, Us&
 15. _Mandates_: `T` is a complete type.
 
 16. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Direct-non-list-initializes an owned object of type `T` with `std​::​forward<Us>(us...)`.
+    Constructs an owned object of type `T` with `std​::​forward<Us>(us...)`.
 
 17. _Postconditions_: `*this` is not valueless.
 
@@ -802,9 +802,9 @@ constexpr indirect(allocator_arg_t, const Allocator& a,
 
 19. _Mandates_: `T` is a complete type.
 
-20. _Effects_: `alloc` is direct-non-list-initialized with `a`. If
-    `other` is valueless, `*this` is valueless. Otherwise, copy constructs an
-    owned object of type `T` with `*other`.
+20. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other` is
+    valueless, `*this` is valueless. Otherwise, constructs an owned object of
+    type `T` with `*other`.
 
 ```c++
 constexpr indirect(indirect&& other) noexcept;
@@ -1226,8 +1226,8 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a);
 
 7. _Mandates_: `T` is a complete type.
 
-8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Value
-initializes an owned object of type `T`.
+8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
+   owned object of type `T` with no arguments.
 
 9. _Postconditions_: `*this` is not valueless.
 
@@ -1260,7 +1260,7 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a,
 14. _Mandates_: `T` is a complete type.
 
 15. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Direct-non-list-initializes an owned object of type `U` with `std​::​forward<Ts>(ts...)`.
+    Constructs an owned object of type `U` with `std​::​forward<Ts>(ts...)`.
 
 16. _Postconditions_: `*this` is not valueless.  The owned instance targets an
   object of type `U` constructed  with `std::forward<Ts>(ts)...`.
@@ -1280,10 +1280,10 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
 
 18. _Mandates_: `T` is a complete type.
 
-19. _Effects_: `alloc` is direct-non-list-initialized with `alloc`. If
-    `other` is valueless, `*this` is valueless. Otherwise, copy constructs an
-    owned object of type `U`, where `U` is the type of the owned object in
-    `other`, with the owned object in `other`.
+19. _Effects_: `alloc` is direct-non-list-initialized with `alloc`. If `other`
+    is valueless, `*this` is valueless. Otherwise, constructs an owned object of
+    type `U`, where `U` is the type of the owned object in `other`, with the
+    owned object in `other`.
 
 ```c++
 constexpr polymorphic(polymorphic&& other) noexcept;

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -71,7 +71,7 @@ should not be considered in isolation.
 ### Changes in R4
 
 * Use constraints to require that the object owned by `indirect` is
-  copy-constructible. This ensures that `std::is_copy_constructible_v` does not
+  copy constructible. This ensures that `std::is_copy_constructible_v` does not
   give misleading results.
 
 * Modify comparison of `indirect` allow comparsion of valueless objects.
@@ -1560,26 +1560,20 @@ Both `indirect` and `polymorphic` support incomplete types. Support for an
 incomplete type requires deferring the instantiation of functions with
 requirements until they are used.
 
-For example, the default constructor of `indirect` requires that `T` is default
-constructible. We can't write this constraint as a requirement on `T` because
+The default constructor of `indirect` requires that `T` is default
+constructible. We cannot write this constraint as a requirement on `T` because
 that would require `T` to be a complete type at class instantiation time.
 Instead we write the constraint as a requirement on a deduced type `TT` to defer
 evaluation of the constraint until the default constructor is instantiated.
 
 ```c++
 template <typename TT = T>
-indirect() requires std::is_default_constructible_v<TT>;
+indirect() requires is_default_constructible_v<TT>;
 ```
 
 We can use this technique to write constraints on the default constructor of
 `indirect` and `polymorphic`. Both `indirect` and `polymorphic` are
 conditionally default constructible.
-
-The same technique cannot be used for the copy or move constructor of `indirect`
-because the copy or move constructor cannot be a template. We make `indirect`
-unconditionally copy and move constructible. This could be relaxed in a future
-version of the C++ standard, as a non-breaking change, if it was possible to
-defer the instantiation of the copy or move constructor.
 
 The same technique cannot be used for the copy or move constructor of
 `polymorphic` because that would require type information on an open set of
@@ -1588,6 +1582,27 @@ that is derived from `T`, we cannot write a constraint that requires that all
 such types are copy constructible. We make `polymorphic` unconditionally copy
 and move constructible. The authors do not envisage that this could be relaxed
 in a future version of the C++ standard.
+
+While a copy constructor cannot be a template, in C++20 and later we can
+conditionally constrain copy construction of `indirect` by defining:
+
+```c++
+indirect(const indirect& other) requires false = delete;
+
+template <typename TT = T>
+indirect(const indirect& other) requires is_copy_constructible_v<TT>;
+```
+
+An instantiation of the function template with `TT=T` is added to the overload
+set when `indirect` is copy-constructed and will be selected if the owned object
+type `T` is copy constructible. This would make copy construction conditional
+for `indirect` but not for `polymorphic`. We opt for consistency and make copy
+construction unconditional for both `indirect` and `polymorphic`. Making
+`indirect` conditionally copy constructible in a future version of the C++
+standard would require adding a template function as above and would be an ABI
+break. It might be simpler to add new types for non-copyable `indirect` and
+`polymorphic` objects, although we do not propose the addition of such types in
+this draft.
 
 ### Implicit conversions
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -875,7 +875,7 @@ constexpr indirect& operator=(const indirect& other);
   Otherwise, if `alloc != other.alloc` or `this` is valueless, a new owned
   object is constructed in `*this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument, using either the allocator in `this` or the allocator
+  `other` as the argument, using either the allocator in `*this` or the allocator
   in `other` if the allocator needs updating. The previously owned object in
   `*this`, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
   and then the storage is deallocated.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -47,6 +47,9 @@ should not be considered in isolation.
 * Add more explicit wording for use of `allocator_traits::construct` in
   `indirect` and `polymorphic` constructors.
 
+* Prevent `indirect` and `polymorphic` classes from being instantiated with
+  `in_place_t` and specializations of `in_place_type_t`.
+
 ### Changes in R7
 
 * Discuss `indirect`'s non-conditional copy constructor in the light of

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -595,7 +595,7 @@ needed.
 
 3. Constructing an owned object using an allocator `a` and arguments `args...`
 means calling `allocator_traits<allocator_type>::construct(a, p, args...)` where
-`p` is a pointer to suitable storage.
+`p` is a pointer obtained by calling `allocator_traits<allocator_type>::allocate`.
 
 // DRAFTING NOTE: [indirect.general]#3 modeled on [container.reqmts]#64
 
@@ -1106,11 +1106,11 @@ program is ill-formed. Every object of type `polymorphic<T, Allocator>` uses an
 object of type `Allocator` to allocate and free storage for the owned object as
 needed.
 
-3. Constructing an owned object using an allocator `a` and arguments
-`args...` means calling `allocator_traits<allocator_type>::rebind_traits<U>::construct(a, p,
-args...)` where `p` is a pointer to suitable storage and `U` is
-either `allocator_type::value_type` or an internal type used by the polymorphic
-value.
+3. Constructing an owned object using an allocator `a` and arguments `args...`
+means calling `allocator_traits<allocator_type>::rebind_traits<U>::construct(a,
+p, args...)` where `p is a pointer obtained by calling
+allocator_traits<allocator_type>::rebind_traits<U>::allocate` and `U` is either
+`allocator_type::value_type` or an internal type used by the polymorphic value.
 
 4. Copy constructors for a polymorphic value obtain an allocator by calling
 `allocator_traits<allocator_type>::select_on_container_copy_construction` on the

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1352,7 +1352,7 @@ constexpr polymorphic& operator=(const polymorphic& other);
   If `allocator_traits<Alloc>::propagate_on_container_copy_assignment` is
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
-  If `other` is not valueless, a new owned object is constructed in `this` using
+  If `other` is not valueless, a new owned object is constructed in `*this` using
   `allocator_traits<allocator_type>::rebind_traits::construct` with the owned
   object from `other` as the argument, using either the allocator in `this` or
   the allocator in `other` if the allocator needs updating.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -783,7 +783,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a, in_place_t, Us&
 15. _Mandates_: `T` is a complete type.
 
 16. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Constructs an owned object of type `T` with `std​::​forward<Us>(us...)`.
+    Constructs an owned object of type `T` with `std​::​forward<Us>(us)...`.
 
 17. _Postconditions_: `*this` is not valueless.
 
@@ -1260,7 +1260,7 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a,
 14. _Mandates_: `T` is a complete type.
 
 15. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Constructs an owned object of type `U` with `std​::​forward<Ts>(ts...)`.
+    Constructs an owned object of type `U` with `std​::​forward<Ts>(ts)...`.
 
 16. _Postconditions_: `*this` is not valueless.  The owned instance targets an
   object of type `U` constructed  with `std::forward<Ts>(ts)...`.

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -872,13 +872,13 @@ constexpr indirect& operator=(const indirect& other);
   Otherwise, if `alloc == other.alloc` and `this` is not valueless, the owned
   object is assigned to `*other`.
 
-  Otherwise, if `alloc != other.alloc` or `this` is valueless, a new owned
-  object is constructed in `*this` using
+  Otherwise a new owned object is constructed in `*this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument, using either the allocator in `*this` or the allocator
-  in `other` if the allocator needs updating. The previously owned object in
-  `*this`, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
-  and then the storage is deallocated.
+  `other` as the argument, using either the allocator in `*this` or the
+  allocator in `other` if the allocator needs updating. The previously owned
+  object in `*this`, if any, is destroyed using
+  `allocator_traits<allocator_type>::destroy` and then the storage is
+  deallocated.
 
   If the allocator needs updating, the allocator in `this` is replaced with a
   copy of the allocator in `other`.
@@ -910,8 +910,7 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   `other`; the owned object in `other`, if any, is then destroyed using
   `allocator_traits<allocator_type>::destroy` and then the storage is deallocated.
 
-  Otherwise, if `alloc != other.alloc` or `this` is valueless, a new owned
-  object is constructed in `*this` using
+  Otherwise a new owned object is constructed in `*this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
   `other` as the argument as an rvalue, using either the allocator in `*this` or
   the allocator in `other` if the allocator needs updating. The previous owned

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -911,7 +911,7 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   `allocator_traits<allocator_type>::destroy` and then the storage is deallocated.
 
   Otherwise, if `alloc != other.alloc` or `this` is valueless, a new owned
-  object is constructed in `this` using
+  object is constructed in `*this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
   `other` as the argument as an rvalue, using either the allocator in `this` or
   the allocator in `other` if the allocator needs updating. The previous owned

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -913,7 +913,7 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   Otherwise, if `alloc != other.alloc` or `this` is valueless, a new owned
   object is constructed in `*this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument as an rvalue, using either the allocator in `this` or
+  `other` as the argument as an rvalue, using either the allocator in `*this` or
   the allocator in `other` if the allocator needs updating. The previous owned
   object in `*this`, if any, is destroyed using
   `allocator_traits<allocator_type>::destroy` and then the storage is

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1354,7 +1354,7 @@ constexpr polymorphic& operator=(const polymorphic& other);
 
   If `other` is not valueless, a new owned object is constructed in `*this` using
   `allocator_traits<allocator_type>::rebind_traits::construct` with the owned
-  object from `other` as the argument, using either the allocator in `this` or
+  object from `other` as the argument, using either the allocator in `*this` or
   the allocator in `other` if the allocator needs updating.
 
   The previous owned object in `*this`, if any, is destroyed using

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -3,7 +3,7 @@
 
 ISO/IEC JTC1 SC22 WG21 Programming Language C++
 
-P3019R7
+D3019R8
 
 Working Group: Library Evolution, Library
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1303,10 +1303,9 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
     valueless, `*this` is valueless. Otherwise, if `alloc == other.alloc` either
     constructs an object of type `polymorphic` that owns the owned value of
     other, making `other` valueless; or, owns an object of the same type
-    constructed from the owned value of `other` using the specified allocator,
-    considering that owned value as an rvalue. Otherwise if `alloc !=
-    other.alloc`, constructs an object of type `polymorphic`, considering that
-    owned value as an rvalue.
+    constructed from the owned value of `other` considering that owned value as
+    an rvalue. Otherwise if `alloc != other.alloc`, constructs an object of type
+    `polymorphic`, considering that owned value as an rvalue.
 
   _[Drafting note: The above is intended to permit a small-buffer-optimization
   and handle the case where allocators compare equal but we do not want to swap

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -903,7 +903,7 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
   If `other` is valueless, `*this` becomes valueless and the owned object in
-  this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
+  `*this`, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
   and then the storage is deallocated.
 
   Otherwise, if `alloc == other.alloc`, swaps the owned objects in `this` and

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -56,7 +56,8 @@ should not be considered in isolation.
 
 * Amend wording for swap to consider the valueless state.
 
-* Remove comparison operators for `indirect` where they can be compiler-synthesized.
+* Remove comparison operators for `indirect` where they can be
+  compiler-synthesized.
 
 * Rename erroneous exposition only variable `allocator` to `alloc`.
 
@@ -70,9 +71,9 @@ should not be considered in isolation.
 
 ### Changes in R4
 
-* Use constraints to require that the object owned by `indirect` is
-  copy constructible. This ensures that `std::is_copy_constructible_v` does not
-  give misleading results.
+* Use constraints to require that the object owned by `indirect` is copy
+  constructible. This ensures that `std::is_copy_constructible_v` does not give
+  misleading results.
 
 * Modify comparison of `indirect` allow comparsion of valueless objects.
   Comparisons are implemented in terms of `operator==` and `operator<=>`
@@ -106,8 +107,7 @@ should not be considered in isolation.
 * Add constructor `indirect(U&& u, Us&&... us)` overload and requisite
   constraints.
 
-* Add constructor `polymorphic(allocator_arg_t, const Allocator& a)`
-  overload.
+* Add constructor `polymorphic(allocator_arg_t, const Allocator& a)` overload.
 
 * Add discussion on similarities and differences with variant.
 
@@ -595,19 +595,20 @@ needed.
 
 3. Constructing an owned object using an allocator `a` and arguments `args...`
 means calling `allocator_traits<allocator_type>::construct(a, p, args...)` where
-`p` is a pointer obtained by calling `allocator_traits<allocator_type>::allocate`.
+`p` is a pointer obtained by calling
+`allocator_traits<allocator_type>::allocate`.
 
 4. Copy constructors for an indirect value obtain an allocator by calling
 `allocator_traits<allocator_type>::select_on_container_copy_construction` on the
 allocator belonging to the indirect value being copied. Move constructors obtain
 an allocator by move construction from the allocator belonging to the object
-being moved. All other constructors for these types take a `const allocator_type&
-argument`. _[Note 3: If an invocation of a constructor uses the default value of
-an optional allocator argument, then the allocator type must support
-value-initialization. --end note]_ A copy of this allocator is used for any
-memory allocation and element construction performed by these constructors and
-by all member functions during the lifetime of each indirect value object, or
-until the allocator is replaced. The allocator may be replaced only via
+being moved. All other constructors for these types take a `const
+allocator_type& argument`. _[Note 3: If an invocation of a constructor uses the
+default value of an optional allocator argument, then the allocator type must
+support value-initialization. --end note]_ A copy of this allocator is used for
+any memory allocation and element construction performed by these constructors
+and by all member functions during the lifetime of each indirect value object,
+or until the allocator is replaced. The allocator may be replaced only via
 assignment or `swap()`. Allocator replacement is performed by copy assignment,
 move assignment, or swapping of the allocator only if
 
@@ -751,7 +752,7 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a);
 7. _Mandates_: `T` is a complete type.
 
 8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs owned
-   object of type `T` with an empty argument list.
+   object of type `T` with an empty argument list, using the allocator `alloc`.
 
 9. _Postconditions_: `*this` is not valueless.
 
@@ -782,8 +783,9 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a, in_place_t, Us&
 
 15. _Mandates_: `T` is a complete type.
 
-16. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Constructs an owned object of type `T` with `std​::​forward<Us>(us)...`.
+16. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
+    owned object of type `T` with `std​::​forward<Us>(us)...`, using the
+    allocator `alloc`.
 
 17. _Postconditions_: `*this` is not valueless.
 
@@ -804,7 +806,7 @@ constexpr indirect(allocator_arg_t, const Allocator& a,
 
 20. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other` is
     valueless, `*this` is valueless. Otherwise, constructs an owned object of
-    type `T` with `*other`.
+    type `T` with `*other`, using the allocator `alloc`.
 
 ```c++
 constexpr indirect(indirect&& other) noexcept;
@@ -818,11 +820,11 @@ constexpr indirect(allocator_arg_t, const Allocator& a, indirect&& other)
   noexcept(allocator_traits<Allocator>::is_always_equal);
 ```
 
-22. _Effects_: `alloc` is direct-non-list-initialized with `a`. If
-    `other` is valueless, `*this` is valueless. Otherwise, if `alloc ==
-    other.alloc` constructs an object of type `indirect` that owns the owned
-    value of other; `other` is valueless. Otherwise constructs an owned object of type
-    `T` with `*std::move(other)`.
+22. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other` is
+    valueless, `*this` is valueless. Otherwise, if `alloc == other.alloc`
+    constructs an object of type `indirect` that owns the owned value of other;
+    `other` is valueless. Otherwise constructs an owned object of type `T` with
+    `*std::move(other)`, using the allocator `alloc`.
 
 23. _[Note: The use of this function may require that `T` be a complete type
     dependent on behavour of the allocator. — end note]_
@@ -852,9 +854,9 @@ constexpr indirect& operator=(const indirect& other);
   If `std::allocator_traits<Alloc>::propagate_on_container_copy_assignment` is
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
-  If `other` is valueless, `*this` becomes valueless and the owned value in this,
-  if any, is destroyed using `allocator_traits<allocator_type>::destroy` and then
-  deallocated using `allocator_traits<allocator_type>::deallocate`.
+  If `other` is valueless, `*this` becomes valueless and the owned value in
+  this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
+  and then deallocated using `allocator_traits<allocator_type>::deallocate`.
 
   Otherwise, if `alloc == other.alloc` and `this` is not valueless, the owned
   object is assigned to `*other`.
@@ -862,11 +864,10 @@ constexpr indirect& operator=(const indirect& other);
   Otherwise, if `alloc != other.alloc` or `this` is valueless, a new owned
   object is constructed in `this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument, with memory allocated using either the allocator in
-  `this` or the allocator in `other` if the allocator needs updating. The
-  previously owned object in this, if any, is destroyed using
-  `allocator_traits<allocator_type>::destroy` and then deallocated using
-  `allocator_traits<allocator_type>::deallocate`.
+  `other` as the argument, using either the allocator in `this` or the allocator
+  in `other` if the allocator needs updating. The previously owned object in
+  this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
+  and then deallocated using `allocator_traits<allocator_type>::deallocate`.
 
   If the allocator needs updating, the allocator in `this` is replaced with a
   copy of the allocator in `other`.
@@ -890,9 +891,9 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   `std::allocator_traits<Alloc>::propagate_on_container_move_assignment` is
   `true` and `alloc != other.alloc` then the allocator needs updating.
 
-  If `other` is valueless, `*this` becomes valueless and the owned value in this,
-  if any, is destroyed using `allocator_traits<allocator_type>::destroy` and then
-  deallocated using `allocator_traits<allocator_type>::deallocate`.
+  If `other` is valueless, `*this` becomes valueless and the owned value in
+  this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
+  and then deallocated using `allocator_traits<allocator_type>::deallocate`.
 
   Otherwise if `alloc == other.alloc`, swaps the owned objects in `this` and
   `other`; the owned object in `other`, if any, is then destroyed using
@@ -902,9 +903,9 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   Otherwise , if `alloc != other.alloc` or `this` is valueless, a new owned
   object is constructed in `this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument as an rvalue, with memory allocated using either the
-  allocator in `this` or the allocator in `other` if the allocator needs
-  updating. The previous owned object in this, if any, is destroyed using
+  `other` as the argument as an rvalue, using either the allocator in `this` or
+  the allocator in `other` if the allocator needs updating. The previous owned
+  object in this, if any, is destroyed using
   `allocator_traits<allocator_type>::destroy` and then deallocated using
   `allocator_traits<allocator_type>::deallocate`.
 
@@ -981,8 +982,8 @@ constexpr void swap(indirect& other) noexcept(
   || allocator_traits::is_always_equal::value);
 ```
 
-1. _Effects_: Swaps the states of `*this` and `other`, exchanging owned objects or
-  valueless states. If
+1. _Effects_: Swaps the states of `*this` and `other`, exchanging owned objects
+  or valueless states. If
   `allocator_traits<allocator_type>::propagate_on_container_swap::value` is
   `true`, then `allocator_type` shall meet the _Cpp17Swappable_ requirements and
   the allocators of `*this` and `other` are exchanged by calling `swap` as
@@ -1228,7 +1229,8 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a);
 7. _Mandates_: `T` is a complete type.
 
 8. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
-   owned object of type `T` with an empty argument list.
+   owned object of type `T` with an empty argument list using the allocator
+   `alloc`.
 
 9. _Postconditions_: `*this` is not valueless.
 
@@ -1260,8 +1262,9 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a,
 
 14. _Mandates_: `T` is a complete type.
 
-15. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Constructs an owned object of type `U` with `std​::​forward<Ts>(ts)...`.
+15. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
+    owned object of type `U` with `std​::​forward<Ts>(ts)...` using the
+    allocator `alloc`.
 
 16. _Postconditions_: `*this` is not valueless.  The owned instance targets an
   object of type `U` constructed  with `std::forward<Ts>(ts)...`.
@@ -1284,7 +1287,7 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
 19. _Effects_: `alloc` is direct-non-list-initialized with `alloc`. If `other`
     is valueless, `*this` is valueless. Otherwise, constructs an owned object of
     type `U`, where `U` is the type of the owned object in `other`, with the
-    owned object in `other`.
+    owned object in `other` using the allocator `alloc`.
 
 ```c++
 constexpr polymorphic(polymorphic&& other) noexcept;
@@ -1304,7 +1307,8 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
     other, making `other` valueless; or, owns an object of the same type
     constructed from the owned value of `other` considering that owned value as
     an rvalue. Otherwise if `alloc != other.alloc`, constructs an object of type
-    `polymorphic`, considering that owned value as an rvalue.
+    `polymorphic`, considering that owned value as an rvalue, using the
+    allocator `alloc`.
 
   _[Drafting note: The above is intended to permit a small-buffer-optimization
   and handle the case where allocators compare equal but we do not want to swap
@@ -1341,8 +1345,8 @@ constexpr polymorphic& operator=(const polymorphic& other);
 
   If `other` is not valueless, a new owned object is constructed in `this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument, with memory allocated using either the allocator in
-  `this` or the allocator in `other` if the allocator needs updating.
+  `other` as the argument, using either the allocator in `this` or the allocator
+  in `other` if the allocator needs updating.
 
   The previous owned object in this, if any, is destroyed using
   `allocator_traits<allocator_type>::destroy` and then deallocated using
@@ -1376,9 +1380,9 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
   Otherwise if `alloc != other.alloc`; if `other` is not valueless, a new owned
   object is constructed in `this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
-  `other` as the argument as an rvalue, with memory allocated using either the
-  allocator in `this` or the allocator in `other` if the allocator needs
-  updating. The previous owned object in this, if any, is destroyed using
+  `other` as the argument as an rvalue, using either the allocator in `this` or
+  the allocator in `other` if the allocator needs updating. The previous owned
+  object in this, if any, is destroyed using
   `allocator_traits<allocator_type>::destroy` and then deallocated using
   `allocator_traits<allocator_type>::deallocate`.
 

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -834,7 +834,7 @@ constexpr indirect(allocator_arg_t, const Allocator& a, indirect&& other)
 22. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other` is
     valueless, `*this` is valueless. Otherwise, if `alloc == other.alloc`
     constructs an object of type `indirect` that owns the owned object of other;
-    `other` is valueless. Otherwise constructs an owned object of type `T` with
+    `other` is valueless. Otherwise, constructs an owned object of type `T` with
     `*std::move(other)`, using the allocator `alloc`.
 
 23. _[Note: The use of this function may require that `T` be a complete type
@@ -906,11 +906,11 @@ constexpr indirect& operator=(indirect&& other) noexcept(
   this, if any, is destroyed using `allocator_traits<allocator_type>::destroy`
   and then the storage is deallocated.
 
-  Otherwise if `alloc == other.alloc`, swaps the owned objects in `this` and
+  Otherwise, if `alloc == other.alloc`, swaps the owned objects in `this` and
   `other`; the owned object in `other`, if any, is then destroyed using
   `allocator_traits<allocator_type>::destroy` and then the storage is deallocated.
 
-  Otherwise , if `alloc != other.alloc` or `this` is valueless, a new owned
+  Otherwise, if `alloc != other.alloc` or `this` is valueless, a new owned
   object is constructed in `this` using
   `allocator_traits<allocator_type>::construct` with the owned object from
   `other` as the argument as an rvalue, using either the allocator in `this` or
@@ -1315,7 +1315,7 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
     constructs an object of type `polymorphic` that owns the owned object of
     other, making `other` valueless; or, owns an object of the same type
     constructed from the owned object of `other` considering that owned object as
-    an rvalue. Otherwise if `alloc != other.alloc`, constructs an object of type
+    an rvalue. Otherwise, if `alloc != other.alloc`, constructs an object of type
     `polymorphic`, considering that owned object as an rvalue, using the
     allocator `alloc`.
 
@@ -1386,7 +1386,7 @@ constexpr polymorphic& operator=(polymorphic&& other) noexcept(
   `allocator_traits<allocator_type>::rebind_traits::destroy` and then the
   storage is deallocated.
 
-  Otherwise if `alloc != other.alloc`; if `other` is not valueless, a new owned
+  Otherwise, if `alloc != other.alloc`; if `other` is not valueless, a new owned
   object is constructed in `this` using
   `allocator_traits<allocator_type>::rebind_traits::construct` with the owned
   object from `other` as the argument as an rvalue, using either the allocator

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -597,8 +597,6 @@ needed.
 means calling `allocator_traits<allocator_type>::construct(a, p, args...)` where
 `p` is a pointer obtained by calling `allocator_traits<allocator_type>::allocate`.
 
-// DRAFTING NOTE: [indirect.general]#3 modeled on [container.reqmts]#64
-
 4. Copy constructors for an indirect value obtain an allocator by calling
 `allocator_traits<allocator_type>::select_on_container_copy_construction` on the
 allocator belonging to the indirect value being copied. Move constructors obtain

--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1139,7 +1139,7 @@ or (64.3) `allocator_traits<allocator_type>::propagate_on_container_swap::value`
 is true within the implementation of the corresponding polymorphic value
 operation.
 
-4. A program that instantiates the definition of polymorphic for a non-object
+5. A program that instantiates the definition of polymorphic for a non-object
    type, an array type, a specialization of `in_place_type_t` or a cv-qualified
    type is ill-formed.
 

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -219,9 +219,8 @@ A. _Constraints_: `is_constructible_v<T, U>` is true.
 
 B. _Mandates_: `T` is a complete type.
 
-
 C. _Effects_: If `*this` is valueless then equivalent to
-   `*this = indirect<T>(std::forward<U>(u))`.
+   `*this = indirect(allocator_arg, alloc, std::forward<U>(u));`.
    Otherwise, equivalent to `**this = std::forward<U>(u)`.
 
 D. _Returns_: A reference to `*this`.

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -178,7 +178,7 @@ F. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
 
 ```c++
 template<class I, class... Us>
-explicit constexpr indirect(in_place_t, std::initializer_list<I> ilist,
+explicit constexpr indirect(in_place_t, initializer_list<I> ilist,
                             Us&&... us);
 ```
 

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -173,8 +173,8 @@ D. _Constraints_: `is_constructible_v<T, U>` is true.
 E. _Mandates_: `T` is a complete type.
 
 F. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Direct-non-list-initializes an owned object of type `T` using the specified
-    allocator with `std​::​forward<U>(u)`.
+    Direct-non-list-initializes an owned object of type `T` with
+    `std​::​forward<U>(u)`.
 
 ```c++
 template<class I, class... Us>
@@ -205,8 +205,8 @@ J. _Constraints_: `is_copy_constructible_v<T>` is `true`.
 K. _Mandates_: `T` is a complete type.
 
 L. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Direct-non-list-initializes an owned object of type `T` using the specified
-    allocator with `ilist, std​::​forward<U>(u)`.
+    Direct-non-list-initializes an owned object of type `T` with `ilist,
+    std​::​forward<U>(u)`.
 
 ### X.Y.5 Assignment [indirect.assign]
 

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -265,6 +265,7 @@ A. _Constraints_: `is_base_of_v<T, std::remove_cvref_t<U>>` is `true`.
    `is_copy_constructible_v<remove_cvref_t<U>>` is `true`.
    `is_same_v<remove_cvref_t<U>, polymorphic>` is `false`.
    `is_default_constructible_v<allocator_type>` is `true`.
+   `remove_cvref_t<U>` is not a specialization of `in_place_type_t`.
 
 B. _Mandates_: `T` is a complete type.
 
@@ -279,6 +280,7 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a, U&& u);
 D. _Constraints_: `is_base_of_v<T, std::remove_cvref_t<U>>` is `true`.
    `is_copy_constructible_v<remove_cvref_t<U>>` is `true`.
    `is_same_v<remove_cvref_t<U>, polymorphic>` is `false`.
+   `remove_cvref_t<U>` is not a specialization of `in_place_type_t`.
 
 E. _Mandates_: `T` is a complete type.
 

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -220,7 +220,7 @@ A. _Constraints_: `is_constructible_v<T, U>` is true.
 B. _Mandates_: `T` is a complete type.
 
 
-C. _Effects_: If `this` is valueless then equivalent to
+C. _Effects_: If `*this` is valueless then equivalent to
    `*this = indirect<T>(std::forward<U>(u))`.
    Otherwise, equivalent to `**this = std::forward<U>(u)`.
 

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -172,9 +172,8 @@ D. _Constraints_: `is_constructible_v<T, U>` is true.
 
 E. _Mandates_: `T` is a complete type.
 
-F. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Direct-non-list-initializes an owned object of type `T` with
-    `std​::​forward<U>(u)`.
+F. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
+    owned object of type `T` with `std​::​forward<U>(u)`.
 
 ```c++
 template<class I, class... Us>
@@ -204,9 +203,8 @@ J. _Constraints_: `is_copy_constructible_v<T>` is `true`.
 
 K. _Mandates_: `T` is a complete type.
 
-L. _Effects_: `alloc` is direct-non-list-initialized with `a`.
-    Direct-non-list-initializes an owned object of type `T` with `ilist,
-    std​::​forward<U>(u)`.
+L. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
+    owned object of type `T` with `ilist, std​::​forward<U>(u)`.
 
 ### X.Y.5 Assignment [indirect.assign]
 

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -215,7 +215,7 @@ constexpr indirect& operator=(U&& u);
 ```
 
 A. _Constraints_: `is_constructible_v<T, U>` is true.
-  `is_assignable_v<T,U>` is true.
+  `is_assignable_v<T&,U>` is true.
 
 B. _Mandates_: `T` is a complete type.
 

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -279,7 +279,6 @@ explicit constexpr polymorphic(allocator_arg_t, const Allocator& a, U&& u);
 
 D. _Constraints_: `is_base_of_v<T, std::remove_cvref_t<U>>` is `true`.
    `is_copy_constructible_v<remove_cvref_t<U>>` is `true`.
-   `is_same_v<remove_cvref_t<U>, in_place_t>` is `false`.
    `is_same_v<remove_cvref_t<U>, polymorphic>` is `false`.
 
 E. _Mandates_: `T` is a complete type.

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -151,7 +151,7 @@ explicit constexpr indirect(U&& u);
 ```
 
 A. _Constraints_: `is_constructible_v<T, U>` is true.
-   `is_copy_constructible_v<U>` is `true`. `is_same_v<remove_cvref_t<U>,
+   `is_copy_constructible_v<T>` is `true`. `is_same_v<remove_cvref_t<U>,
    in_place_t>` is `false`. `is_same_v<remove_cvref_t<U>, indirect>` is `false`.
    `is_default_constructible_v<allocator_type>` is `true`.
 

--- a/DRAFT_COROLLARY.md
+++ b/DRAFT_COROLLARY.md
@@ -24,7 +24,8 @@ _Sean Parent \<<sparent@adobe.com>\>_
  - [Acknowledgements](#acknowledgements)
  - [References](#references)
 
-[//]: <> (<=============================================================================>)
+[//]: <>
+    (<=============================================================================>)
 
 ## Introduction
 
@@ -42,8 +43,8 @@ In line with `optional` and `variant`, we add converting constructors to both
 `indirect` and `polymorphic` so they can be constructed from single values
 without the need to use `in_place` or `in_place_type`. As `indirect` and
 `polymorphic` are allocator-aware types, we also provide allocator-extended
-versions of these constructors, in line with those from `basic_optional` [2]
-and existing constructors from `indirect` and `polymorphic`.
+versions of these constructors, in line with those from `basic_optional` [2] and
+existing constructors from `indirect` and `polymorphic`.
 
 As `indirect` and `polymorphic` will use dynamic memory, the converting
 constructors are marked as explicit, the same as other constructors in
@@ -52,8 +53,8 @@ constructors are marked as explicit, the same as other constructors in
 ### Initializer-list constructors
 
 We add initializer-list constructors to both `indirect` and `polymorphic` in
-line with those in `optional` and `variant`. As `indirect` and `polymorphic`
-are allocator-aware types, we provide allocator-extended versions of these
+line with those in `optional` and `variant`. As `indirect` and `polymorphic` are
+allocator-aware types, we provide allocator-extended versions of these
 constructors, in line with those from `basic_optional` [2] and existing
 constructors from `indirect` and `polymorphic`.
 
@@ -73,8 +74,8 @@ template <class U = T>
 constexpr optional& operator=(U&& u);
 ```
 
-When assigning to an `indirect`, there is potential for optimisation if there
-is an existing owned object to be assigned to:
+When assigning to an `indirect`, there is potential for optimisation if there is
+an existing owned object to be assigned to:
 
 ```c++
 indirect<int> i;
@@ -87,8 +88,8 @@ if (!i.valueless_after_move()) {
 ```
 
 With converting assignment, handling the valueless state and potentially
-creating a new indirect object is done within the converting assignment.
-The code below is equivalent to the code above:
+creating a new indirect object is done within the converting assignment. The
+code below is equivalent to the code above:
 
 ```c++
 indirect<int> i;
@@ -105,8 +106,8 @@ not.
 
 ## Technical specifications
 
-Here we update the technical specifications detailed in P3019 [1] to include
-the constructors and assignment operators discussed above.
+Here we update the technical specifications detailed in P3019 [1] to include the
+constructors and assignment operators discussed above.
 
 ### X.Y Class template indirect [indirect]
 
@@ -150,14 +151,14 @@ explicit constexpr indirect(U&& u);
 ```
 
 A. _Constraints_: `is_constructible_v<T, U>` is true.
-   `is_copy_constructible_v<U>` is `true`.
-   `is_same_v<remove_cvref_t<U>, in_place_t>` is `false`.
-   `is_same_v<remove_cvref_t<U>, indirect>` is `false`.
+   `is_copy_constructible_v<U>` is `true`. `is_same_v<remove_cvref_t<U>,
+   in_place_t>` is `false`. `is_same_v<remove_cvref_t<U>, indirect>` is `false`.
    `is_default_constructible_v<allocator_type>` is `true`.
 
 B. _Mandates_: `T` is a complete type.
 
-C. _Effects_: Equivalent to `indirect(allocator_arg_t{}, Allocator(), std::forward<U>(u))`.
+C. _Effects_: Equivalent to `indirect(allocator_arg_t{}, Allocator(),
+std::forward<U>(u))`.
 
 ```c++
 template <class U = T>
@@ -166,14 +167,14 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a,
 ```
 
 D. _Constraints_: `is_constructible_v<T, U>` is true.
-   `is_copy_constructible_v<U>` is `true`.
-   `is_same_v<remove_cvref_t<U>, in_place_t>` is `false`.
-   `is_same_v<remove_cvref_t<U>, indirect>` is `false`.
+   `is_copy_constructible_v<U>` is `true`. `is_same_v<remove_cvref_t<U>,
+   in_place_t>` is `false`. `is_same_v<remove_cvref_t<U>, indirect>` is `false`.
 
 E. _Mandates_: `T` is a complete type.
 
 F. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
-    owned object of type `T` with `std​::​forward<U>(u)`.
+    owned object of type `T` with `std​::​forward<U>(u)`, using the allocator
+    `alloc`.
 
 ```c++
 template<class I, class... Us>
@@ -181,8 +182,8 @@ explicit constexpr indirect(in_place_t, std::initializer_list<I> ilist,
                             Us&&... us);
 ```
 
-G. _Constraints_: `is_copy_constructible_v<T>` is `true`.
-   `is_constructible_v<T, initializer_list<I>, Us...>` is `true`.
+G. _Constraints_: `is_copy_constructible_v<T>` is `true`. `is_constructible_v<T,
+   initializer_list<I>, Us...>` is `true`.
    `is_default_constructible_v<allocator_type>` is `true`.
 
 H. _Mandates_: `T` is a complete type.
@@ -198,13 +199,14 @@ explicit constexpr indirect(allocator_arg_t, const Allocator& a,
                             Us&&... us);
 ```
 
-J. _Constraints_: `is_copy_constructible_v<T>` is `true`.
-   `is_constructible_v<T, initializer_list<I>, Us...>` is `true`.
+J. _Constraints_: `is_copy_constructible_v<T>` is `true`. `is_constructible_v<T,
+   initializer_list<I>, Us...>` is `true`.
 
 K. _Mandates_: `T` is a complete type.
 
 L. _Effects_: `alloc` is direct-non-list-initialized with `a`. Constructs an
-    owned object of type `T` with `ilist, std​::​forward<U>(u)`.
+    owned object of type `T` with `ilist, std​::​forward<U>(u)`, using the
+    allocator `alloc`.
 
 ### X.Y.5 Assignment [indirect.assign]
 
@@ -213,14 +215,14 @@ template <class U>
 constexpr indirect& operator=(U&& u);
 ```
 
-A. _Constraints_: `is_constructible<T, U>` is true.
-  `is_assignable<T,U>` is true.
+A. _Constraints_: `is_constructible<T, U>` is true. `is_assignable<T,U>` is
+  true.
 
 B. _Mandates_: `T` is a complete type.
 
-C. _Effects_: If `this` is valueless then equivalent to
-   `*this = std::move(indirect<T>(std::forward<U>(u)))`.
-   Otherwise, equivalent to `**this = std::forward<U>(u)`.
+C. _Effects_: If `this` is valueless then equivalent to `*this =
+   std::move(indirect<T>(std::forward<U>(u)))`. Otherwise, equivalent to `**this
+   = std::forward<U>(u)`.
 
 D. _Returns_: A reference to `*this`.
 
@@ -290,9 +292,8 @@ F. _Effects_: Equivalent to `polymorphic(std::allocator_arg_t{}, a,
                                  initializer_list<I> ilist, Us&&... us)
 ```
 
-A. _Constraints_: `is_base_of_v<T, U>` is `true`.
-  `is_copy_constructible_v<U>` is `true`.
-  `is_constructible_v<U, initializer_list<I>, Us...>` is `true`.
+A. _Constraints_: `is_base_of_v<T, U>` is `true`. `is_copy_constructible_v<U>`
+  is `true`. `is_constructible_v<U, initializer_list<I>, Us...>` is `true`.
   `is_default_constructible_v<allocator_type>` is `true`.
 
 B. _Mandates_: `T` is a complete type.
@@ -307,15 +308,13 @@ C. _Effects_: Equivalent to `polymorphic(std::allocator_arg_t{}, A{},
                                  initializer_list<I> ilist, Us&&... us)
 ```
 
-D. _Constraints_: `is_base_of_v<T, U>` is `true`.
-  `is_copy_constructible_v<U>` is `true`.
-  `is_constructible_v<U, initializer_list<I>, Us...>` is `true`.
+D. _Constraints_: `is_base_of_v<T, U>` is `true`. `is_copy_constructible_v<U>`
+  is `true`. `is_constructible_v<U, initializer_list<I>, Us...>` is `true`.
 
 E. _Mandates_: `T` is a complete type.
 
 F. _Effects_: Equivalent to `polymorphic(std::allocator_arg_t{}, a,
-  std::in_place_type_t<U>{}, initializer_list<I>(ilist),
-  std::forward<Us>(us))`.
+  std::in_place_type_t<U>{}, initializer_list<I>(ilist), std::forward<Us>(us))`.
 
 ## Reference implementation
 
@@ -330,7 +329,8 @@ draft at extremely short notice.
 
 ## References
 
-[1] _`indirect` and `polymorphic`: Vocabulary Types for Composite Class Design_, \
+[1] _`indirect` and `polymorphic`: Vocabulary Types for Composite Class Design_,
+\
 J. B. Coe, A. Peacock, and S. Parent, 2024 \
 https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3019r6.html
 


### PR DESCRIPTION
We already mention allocators in:  Class template polymorphic general [polymorphic.general] 

_In every specialization `polymorphic<T, Allocator>`, if the type
`allocator_traits<Allocator>::value_type` is not the same type as`T`, the
program is ill-formed. Every object of type `polymorphic<T, Allocator>` uses an
object of type `Allocator` to allocate and free storage for the owned object as
needed. The owned object is constructed using the function
`allocator_traits<allocator_type>::rebind_traits<U>::construct` and destroyed
 using the function
`allocator_traits<allocator_type>::rebind_traits<U>::destroy`, where `U` is
either `allocator_type::value_type` or an internal type used by the polymorphic
value._

There is, perhaps, no need to mention allocators again for individual constructors.