### PR TITLE
Fix typo `alloc` -> `a`

### DIFF
--- a/DRAFT.md
+++ b/DRAFT.md
@@ -1440,7 +1440,7 @@ constexpr polymorphic(allocator_arg_t, const Allocator& a,
                       const polymorphic& other);
 ```
 
-7. _Effects_: `alloc` is direct-non-list-initialized with `alloc`. If `other`
+7. _Effects_: `alloc` is direct-non-list-initialized with `a`. If `other`
     is valueless, `*this` is valueless. Otherwise, constructs an owned object of
     type `U`, where `U` is the type of the owned object in `other`, with the
     owned object in `other` using the allocator `alloc`.


### PR DESCRIPTION
Just a very small typo fix. Please let me know if you need a new bullet point for this in the revision history `Changes in R13`. But I assume not.