### PR TITLE
Fix CI environment to avoid FetchPackage errors

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -109,6 +109,8 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v3
+      - name: Set up environment
+        run: echo "CMAKE_TLS_VERIFY=0" >> $GITHUB_ENV
       - name: Add msbuild to PATH
         if: matrix.settings.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
Avoid hitting errors on Windows CI builds:

```
SSL connect error. If this is due to https certificate verification failure, one may set environment variable CMAKE_TLS_VERIFY=0 to suppress it.
```