### PR TITLE
Fix failing windows CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -109,8 +109,6 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v3
-      - name: Set up environment
-        run: echo "CMAKE_TLS_VERIFY=0" >> $GITHUB_ENV
       - name: Add msbuild to PATH
         if: matrix.settings.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -109,6 +109,8 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v3
+      - name: Set up environment
+        run: echo "CMAKE_TLS_VERIFY=0" >> $GITHUB_ENV
       - name: Add msbuild to PATH
         if: matrix.settings.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v1.0.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if (${XYZ_VALUE_TYPES_IS_NOT_SUBPROJECT})
     if (${BUILD_TESTING})
         FetchContent_Declare(
           googletest
-          URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+          URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
         )
         # For Windows: Prevent overriding the parent project's compiler/linker settings
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Use up-to-date googletest to avoid windows CI timeouts fetching from archive