### PR TITLE
Generate and use compile_commands.json with CMake

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,14 @@
+{
+    "configurations": [
+        {
+            "name": "xyz",
+            "includePath": [],
+            "defines": [],
+            "cppStandard": "c++20",
+            "compileCommands": [
+                "build/compile_commands.json"
+            ]
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools",
+    ]
+}

--- a/scripts/cmake.sh
+++ b/scripts/cmake.sh
@@ -6,7 +6,7 @@ set -eux -o pipefail
 mkdir -p build
 
 # Generate build system specified in build directory with cmake
-cmake -Bbuild -GNinja
+cmake -Bbuild -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 
 # Build the underlying build system via CMake
 cmake --build build


### PR DESCRIPTION
Generate compile_commands.json in CMake builds. 

Configure VsCode to read compile_commands.json from default CMake build directory.