### PR TITLE
Fix CMake warnings

### DIFF
--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -341,7 +341,7 @@ endfunction()
 set_property(GLOBAL PROPERTY global_coverage_test_targets)
 
 function(add_coverage TNAME)
-    message(WARNING "Adding coverage for target "${TNAME})
+    message(WARNING "Adding coverage for target" ${TNAME})
     get_property(tmp GLOBAL PROPERTY global_coverage_test_targets)
     set(tmp "${tmp};${TNAME}")
     set_property(GLOBAL PROPERTY global_coverage_test_targets "${tmp}")

--- a/cmake/xyz_add_test.cmake
+++ b/cmake/xyz_add_test.cmake
@@ -101,7 +101,7 @@ function(xyz_add_test)
 
         include(GoogleTest)
         gtest_discover_tests(${XYZ_NAME}
-            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            WORKING_DIRECTORY $<TARGET_FILE_DIR:${XYZ_NAME}>
         )
 
     endif()

--- a/cmake/xyz_add_test.cmake
+++ b/cmake/xyz_add_test.cmake
@@ -88,6 +88,9 @@ function(xyz_add_test)
         CXX_STANDARD ${XYZ_VERSION}
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     )
 
     target_compile_options(${XYZ_NAME}
@@ -101,7 +104,7 @@ function(xyz_add_test)
 
         include(GoogleTest)
         gtest_discover_tests(${XYZ_NAME}
-            WORKING_DIRECTORY $<TARGET_FILE_DIR:${XYZ_NAME}>
+            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
 
     endif()

--- a/cmake/xyz_add_test.cmake
+++ b/cmake/xyz_add_test.cmake
@@ -104,7 +104,7 @@ function(xyz_add_test)
 
         include(GoogleTest)
         gtest_discover_tests(${XYZ_NAME}
-            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            WORKING_DIRECTORY $<TARGET_FILE_DIR:${XYZ_NAME}>
         )
 
     endif()


### PR DESCRIPTION
Fix warning for google test discovery following https://stackoverflow.com/questions/73457020/how-to-set-working-folder-when-running-ctest

Previously we saw:

```
CMake Warning (dev) at cmake/coverage.cmake:344:
  Syntax Warning in cmake code at column 50

  Argument not separated from preceding token by whitespace.
Call Stack (most recent call first):
  CMakeLists.txt:25 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

...

```
CMake Warning (dev) at /opt/homebrew/share/cmake/Modules/GoogleTest.cmake:559 (cmake_parse_arguments):
  The WORKING_DIRECTORY keyword was followed by an empty string or no value
  at all.  Policy CMP0174 is not set, so cmake_parse_arguments() will unset
  the arg_WORKING_DIRECTORY variable rather than setting it to an empty
  string.
Call Stack (most recent call first):
  cmake/xyz_add_test.cmake:103 (gtest_discover_tests)
  exploration/CMakeLists.txt:3 (xyz_add_test)
This warning is for project developers.  Use -Wno-dev to suppress it.
```