### PR TITLE
Add implementation of polymorphic that uses no vtable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
         ".venv": true,
         "bazel-*": true,
         "build": true,
+    },
+    "files.associations": {
+        "array": "cpp"
     }
 }

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -146,3 +146,26 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "polymorphic_no_vtable",
+    srcs = ["polymorphic_no_vtable.cc"],
+    hdrs = ["polymorphic_no_vtable.h"],
+    copts = ["-Iexternal/value_types/"],
+    defines = ["XYZ_POLYMORPHIC_NO_VTABLE"],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "polymorphic_no_vtable_test",
+    size = "small",
+    srcs = ["polymorphic_test.cc"],
+    deps = [
+        "feature_check",
+        "polymorphic_no_vtable",
+        "tagged_allocator",
+        "test_helpers",
+        "tracking_allocator",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,24 @@ target_sources(polymorphic_cxx17
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/polymorphic_cxx14.cc>
 )
 
+xyz_add_library(
+    NAME polymorphic_no_vtable
+    ALIAS xyz_value_types::polymorphic_no_vtable
+    DEFINITIONS XYZ_POLYMORPHIC_NO_VTABLE
+    VERSION 14
+)
+target_sources(polymorphic_no_vtable
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/polymorphic_no_vtable.h>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/polymorphic_no_vtable.cc>
+)
+
+xyz_add_object_library(
+    NAME polymorphic_no_vtable_cc
+    FILES polymorphic_no_vtable.cc
+    LINK_LIBRARIES polymorphic_no_vtable
+)
+
 if (${XYZ_VALUE_TYPES_IS_NOT_SUBPROJECT})
 
     add_subdirectory(benchmarks)
@@ -188,6 +206,12 @@ if (${XYZ_VALUE_TYPES_IS_NOT_SUBPROJECT})
             LINK_LIBRARIES polymorphic_cxx17
             FILES polymorphic_test.cc
             VERSION 17
+        )
+
+        xyz_add_test(
+            NAME polymorphic_no_vtable_test
+            LINK_LIBRARIES polymorphic_no_vtable
+            FILES polymorphic_test.cc
         )
 
         if (ENABLE_CODE_COVERAGE)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -99,8 +99,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/source.json": "f18d9ad3c4c54945bf422ad584fa6c5ca5b3116ff55a5b1bc77e5c1210be5960",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -526,28 +526,6 @@
         "recordedRepoMappingEntries": [
           [
             "rules_fuzzing+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
-    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
-      "general": {
-        "bzlTransitiveDigest": "84xJEZ1jnXXwo8BXMprvBm++rRt4jsTu9liBxz0ivps=",
-        "usagesDigest": "jTQDdLDxsS43zuRmg1faAjIEPWdLAbDAowI1pInQSoo=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "compatibility_proxy": {
-            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_java+",
             "bazel_tools",
             "bazel_tools"
           ]

--- a/polymorphic_no_vtable.cc
+++ b/polymorphic_no_vtable.cc
@@ -1,0 +1,3 @@
+// A cc file for polymorphic_no_vtable to ensure that the header file can be
+// compiled.
+#include "polymorphic_no_vtable.h"

--- a/polymorphic_no_vtable.h
+++ b/polymorphic_no_vtable.h
@@ -1,0 +1,410 @@
+/* Copyright (c) 2016 The Value Types Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+
+#ifndef XYZ_POLYMORPHIC_H_
+#define XYZ_POLYMORPHIC_H_
+
+#include <cassert>
+#include <concepts>
+#include <initializer_list>
+#include <memory>
+#include <utility>
+
+#ifndef XYZ_POLYMORPHIC_HAS_EXTENDED_CONSTRUCTORS
+#define XYZ_POLYMORPHIC_HAS_EXTENDED_CONSTRUCTORS 1
+#endif  // XYZ_POLYMORPHIC_HAS_EXTENDED_CONSTRUCTORS
+
+namespace xyz {
+
+#ifndef XYZ_UNREACHABLE_DEFINED
+#define XYZ_UNREACHABLE_DEFINED
+
+[[noreturn]] inline void unreachable() {  // LCOV_EXCL_LINE
+#if (__cpp_lib_unreachable >= 202202L)
+  std::unreachable();  // LCOV_EXCL_LINE
+#elif defined(_MSC_VER)
+  __assume(false);  // LCOV_EXCL_LINE
+#else
+  __builtin_unreachable();  // LCOV_EXCL_LINE
+#endif
+}
+#endif  // XYZ_UNREACHABLE_DEFINED
+
+template <class T, class A = std::allocator<T>>
+class polymorphic {
+  struct control_block {
+    using allocator_traits = std::allocator_traits<A>;
+    typename allocator_traits::pointer p_;
+
+    enum class Action { Destroy, Clone, Move };
+    control_block* (*h_)(Action, control_block* self, const A& alloc);
+
+    constexpr void destroy(const A& alloc) { h_(Action::Destroy, this, alloc); }
+
+    constexpr control_block* clone(const A& alloc) {
+      return h_(Action::Clone, this, alloc);
+    }
+
+    constexpr control_block* move(const A& alloc) {
+      return h_(Action::Move, this, alloc);
+    }
+  };
+
+  template <class U>
+  class direct_control_block final : public control_block {
+    union uninitialized_storage {
+      U u_;
+
+      constexpr uninitialized_storage() {}
+
+      constexpr ~uninitialized_storage() {}
+    } storage_;
+
+    using cb_allocator = typename std::allocator_traits<
+        A>::template rebind_alloc<direct_control_block<U>>;
+    using cb_alloc_traits = std::allocator_traits<cb_allocator>;
+
+    using Action = control_block::Action;
+
+    static constexpr control_block* handler(Action action, control_block* self,
+                                            const A& alloc) {
+      direct_control_block* dis = static_cast<direct_control_block*>(self);
+      cb_allocator cb_alloc(alloc);
+      if (action == Action::Destroy) {
+        cb_alloc_traits::destroy(cb_alloc, std::addressof(dis->storage_.u_));
+        cb_alloc_traits::deallocate(cb_alloc, dis, 1);
+        return nullptr;
+      }
+      auto mem = cb_alloc_traits::allocate(cb_alloc, 1);
+      try {
+        if (action == Action::Clone) {
+          cb_alloc_traits::construct(cb_alloc, mem, alloc, dis->storage_.u_);
+        } else {
+          cb_alloc_traits::construct(cb_alloc, mem, alloc,
+                                     std::move(dis->storage_.u_));
+        }
+      } catch (...) {
+        cb_alloc_traits::deallocate(cb_alloc, mem, 1);
+        throw;
+      }
+      return mem;
+    }
+
+   public:
+    template <class... Ts>
+    constexpr direct_control_block(const A& alloc, Ts&&... ts) {
+      cb_allocator cb_alloc(alloc);
+      cb_alloc_traits::construct(cb_alloc, std::addressof(storage_.u_),
+                                 std::forward<Ts>(ts)...);
+      control_block::p_ = std::addressof(storage_.u_);
+      control_block::h_ = &handler;
+    }
+  };
+
+  control_block* cb_;
+
+#if defined(_MSC_VER)
+  // https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/#msvc-extensions-and-abi
+  [[msvc::no_unique_address]] A alloc_;
+#else
+  [[no_unique_address]] A alloc_;
+#endif
+
+  using allocator_traits = std::allocator_traits<A>;
+
+  template <class U, class... Ts>
+  [[nodiscard]] constexpr control_block* create_control_block(
+      Ts&&... ts) const {
+    using cb_allocator = typename std::allocator_traits<
+        A>::template rebind_alloc<direct_control_block<U>>;
+    cb_allocator cb_alloc(alloc_);
+    using cb_alloc_traits = std::allocator_traits<cb_allocator>;
+    auto mem = cb_alloc_traits::allocate(cb_alloc, 1);
+    try {
+      cb_alloc_traits::construct(cb_alloc, mem, alloc_,
+                                 std::forward<Ts>(ts)...);
+      return mem;
+    } catch (...) {
+      cb_alloc_traits::deallocate(cb_alloc, mem, 1);
+      throw;
+    }
+  }
+
+ public:
+  using value_type = T;
+  using allocator_type = A;
+  using pointer = typename allocator_traits::pointer;
+  using const_pointer = typename allocator_traits::const_pointer;
+
+  //
+  // Constructors.
+  //
+
+  explicit constexpr polymorphic()
+    requires std::default_initializable<A>
+      : polymorphic(std::allocator_arg_t{}, A{}) {
+    static_assert(std::default_initializable<T> && std::copy_constructible<T>);
+  }
+
+  template <class U>
+  constexpr explicit polymorphic(U&& u)
+    requires(!std::same_as<polymorphic, std::remove_cvref_t<U>>) &&
+            std::copy_constructible<std::remove_cvref_t<U>> &&
+            std::derived_from<std::remove_cvref_t<U>, T> &&
+            std::default_initializable<A>
+      : polymorphic(std::allocator_arg_t{}, A{}, std::forward<U>(u)) {}
+
+  template <class U, class... Ts>
+  explicit constexpr polymorphic(std::in_place_type_t<U>, Ts&&... ts)
+    requires std::same_as<std::remove_cvref_t<U>, U> &&
+             std::constructible_from<U, Ts&&...> &&
+             std::copy_constructible<U> && std::derived_from<U, T> &&
+             std::default_initializable<A>
+      : polymorphic(std::allocator_arg_t{}, A{}, std::in_place_type<U>,
+                    std::forward<Ts>(ts)...) {}
+
+  template <class U, class I, class... Ts>
+  explicit constexpr polymorphic(std::in_place_type_t<U>,
+                                 std::initializer_list<I> ilist, Ts&&... ts)
+    requires std::same_as<std::remove_cvref_t<U>, U> &&
+             std::constructible_from<U, std::initializer_list<I>, Ts&&...> &&
+             std::copy_constructible<U> && std::derived_from<U, T> &&
+             std::default_initializable<A>
+      : polymorphic(std::allocator_arg_t{}, A{}, std::in_place_type<U>, ilist,
+                    std::forward<Ts>(ts)...) {}
+
+  constexpr polymorphic(const polymorphic& other)
+      : polymorphic(std::allocator_arg_t{},
+                    allocator_traits::select_on_container_copy_construction(
+                        other.alloc_),
+                    other) {}
+
+  constexpr polymorphic(polymorphic&& other) noexcept(
+      allocator_traits::is_always_equal::value)
+      : polymorphic(std::allocator_arg_t{}, other.alloc_, std::move(other)) {}
+
+  //
+  // Allocator-extended constructors.
+  //
+
+  explicit constexpr polymorphic(std::allocator_arg_t, const A& alloc)
+      : alloc_(alloc) {
+    static_assert(std::default_initializable<T> && std::copy_constructible<T>);
+
+    cb_ = create_control_block<T>();
+  }
+
+  template <class U>
+  constexpr explicit polymorphic(std::allocator_arg_t, const A& alloc, U&& u)
+    requires(not std::same_as<polymorphic, std::remove_cvref_t<U>>) &&
+            std::copy_constructible<std::remove_cvref_t<U>> &&
+            std::derived_from<std::remove_cvref_t<U>, T>
+      : alloc_(alloc) {
+    cb_ = create_control_block<std::remove_cvref_t<U>>(std::forward<U>(u));
+  }
+
+  template <class U, class... Ts>
+  explicit constexpr polymorphic(std::allocator_arg_t, const A& alloc,
+                                 std::in_place_type_t<U>, Ts&&... ts)
+    requires std::same_as<std::remove_cvref_t<U>, U> &&
+             std::constructible_from<U, Ts&&...> &&
+             std::copy_constructible<U> && std::derived_from<U, T>
+      : alloc_(alloc) {
+    cb_ = create_control_block<U>(std::forward<Ts>(ts)...);
+  }
+
+  template <class U, class I, class... Ts>
+  explicit constexpr polymorphic(std::allocator_arg_t, const A& alloc,
+                                 std::in_place_type_t<U>,
+                                 std::initializer_list<I> ilist, Ts&&... ts)
+    requires std::same_as<std::remove_cvref_t<U>, U> &&
+             std::constructible_from<U, std::initializer_list<I>, Ts&&...> &&
+             std::copy_constructible<U> && std::derived_from<U, T>
+      : alloc_(alloc) {
+    cb_ = create_control_block<U>(ilist, std::forward<Ts>(ts)...);
+  }
+
+  constexpr polymorphic(std::allocator_arg_t, const A& alloc,
+                        const polymorphic& other)
+      : alloc_(alloc) {
+    if (!other.valueless_after_move()) {
+      cb_ = other.cb_->clone(alloc_);
+    } else {
+      cb_ = nullptr;
+    }
+  }
+
+  constexpr polymorphic(
+      std::allocator_arg_t, const A& alloc,
+      polymorphic&& other) noexcept(allocator_traits::is_always_equal::value)
+      : alloc_(alloc) {
+    if constexpr (allocator_traits::is_always_equal::value) {
+      cb_ = std::exchange(other.cb_, nullptr);
+    } else {
+      if (alloc_ == other.alloc_) {
+        cb_ = std::exchange(other.cb_, nullptr);
+      } else {
+        if (!other.valueless_after_move()) {
+          cb_ = other.cb_->move(alloc_);
+        } else {
+          cb_ = nullptr;
+        }
+      }
+    }
+  }
+
+  //
+  // Destructor.
+  //
+
+  constexpr ~polymorphic() { reset(); }
+
+  //
+  // Assignment operators.
+  //
+
+  constexpr polymorphic& operator=(const polymorphic& other) {
+    if (this == &other) return *this;
+
+    // Check to see if the allocators need to be updated.
+    // We defer actually updating the allocator until later because it may be
+    // needed to delete the current control block.
+    bool update_alloc =
+        allocator_traits::propagate_on_container_copy_assignment::value;
+
+    if (other.valueless_after_move()) {
+      reset();
+    } else {
+      // Constructing a new control block could throw so we need to defer
+      // resetting or updating allocators until this is done.
+
+      // Inlining the allocator into the construct_from call confuses LCOV.
+      auto tmp = other.cb_->clone(update_alloc ? other.alloc_ : alloc_);
+      reset();
+      cb_ = tmp;
+    }
+    if (update_alloc) {
+      alloc_ = other.alloc_;
+    }
+    return *this;
+  }
+
+  constexpr polymorphic& operator=(polymorphic&& other) noexcept(
+      allocator_traits::propagate_on_container_move_assignment::value ||
+      allocator_traits::is_always_equal::value) {
+    if (this == &other) return *this;
+
+    // Check to see if the allocators need to be updated.
+    // We defer actually updating the allocator until later because it may be
+    // needed to delete the current control block.
+    bool update_alloc =
+        allocator_traits::propagate_on_container_move_assignment::value;
+
+    if (other.valueless_after_move()) {
+      reset();
+    } else {
+      if (alloc_ == other.alloc_) {
+        std::swap(cb_, other.cb_);
+        other.reset();
+      } else {
+        // Constructing a new control block could throw so we need to defer
+        // resetting or updating allocators until this is done.
+
+        // Inlining the allocator into the construct_from call confuses LCOV.
+        auto tmp = other.cb_->move(update_alloc ? other.alloc_ : alloc_);
+        reset();
+        cb_ = tmp;
+      }
+    }
+
+    if (update_alloc) {
+      alloc_ = other.alloc_;
+    }
+    return *this;
+  }
+
+  //
+  // Accessors.
+  //
+
+  [[nodiscard]] constexpr pointer operator->() noexcept {
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
+    return cb_->p_;
+  }
+
+  [[nodiscard]] constexpr const_pointer operator->() const noexcept {
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
+    return cb_->p_;
+  }
+
+  [[nodiscard]] constexpr T& operator*() noexcept {
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
+    return *cb_->p_;
+  }
+
+  [[nodiscard]] constexpr const T& operator*() const noexcept {
+    assert(!valueless_after_move());  // LCOV_EXCL_LINE
+    return *cb_->p_;
+  }
+
+  [[nodiscard]] constexpr bool valueless_after_move() const noexcept {
+    return cb_ == nullptr;
+  }
+
+  constexpr allocator_type get_allocator() const noexcept { return alloc_; }
+
+  //
+  // Modifiers.
+  //
+
+  constexpr void swap(polymorphic& other) noexcept(
+      std::allocator_traits<A>::propagate_on_container_swap::value ||
+      std::allocator_traits<A>::is_always_equal::value) {
+    if constexpr (allocator_traits::propagate_on_container_swap::value) {
+      // If allocators move with their allocated objects, we can swap both.
+      std::swap(alloc_, other.alloc_);
+      std::swap(cb_, other.cb_);
+      return;
+    } else /* constexpr */ {
+      if (alloc_ == other.alloc_) {
+        std::swap(cb_, other.cb_);
+      } else {
+        unreachable();  // LCOV_EXCL_LINE
+      }
+    }
+  }
+
+  friend constexpr void swap(polymorphic& lhs, polymorphic& rhs) noexcept(
+      noexcept(lhs.swap(rhs))) {
+    lhs.swap(rhs);
+  }
+
+ private:
+  constexpr void reset() noexcept {
+    if (cb_ != nullptr) {
+      cb_->destroy(alloc_);
+      cb_ = nullptr;
+    }
+  }
+};
+
+}  // namespace xyz
+
+#endif  // XYZ_POLYMORPHIC_H_

--- a/polymorphic_test.cc
+++ b/polymorphic_test.cc
@@ -22,6 +22,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "polymorphic_cxx14.h"
 #endif  // XYZ_POLYMORPHIC_CXX_14
 
+#ifdef XYZ_POLYMORPHIC_NO_VTABLE
+#include "polymorphic_no_vtable.h"
+#endif  // XYZ_POLYMORPHIC_NO_VTABLE
+
 #ifndef XYZ_POLYMORPHIC_H_
 #include "polymorphic.h"
 #endif  // XYZ_POLYMORPHIC_H_


### PR DESCRIPTION
This is an amendment of https://github.com/jbcoe/value_types/pull/567 that introduces a parallel implementation of polymorphic rather than replacing the existing one.

Co-authored with @toughengineer

---

Following discussion in #559 I replaced inheritance and virtual functions with a single pointer to function.

With the current benchmarks I could not reliably measure the difference in performance so I assumed that it is not significantly different.

I could however very easily measure the difference in resulting binary size.
Here's the size of **polymorphic_test.exe** in KB:

|compiler|current size|size after change|difference|
|-|-|-|-|
|MSVC|921|904|-17|
|Clang|996|982|-14|

I did not investigate what exactly contributed to overhead, I bet it's RTTI, and maybe vtables and individual functions a little bit.

Solution with a pointer to a single function (apart from binary size compared to inheritance and virtual functions) is very ABI friendly, and can be made extendable in an ABI compatible way.